### PR TITLE
commission option

### DIFF
--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -13,8 +13,6 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     using DelegationPoolLib for DelegationPool;
     using VestingPositionLib for VestingPosition;
 
-    /// @notice A constant that is used to keep the commission of the delegators
-    uint256 public constant DELEGATORS_COMMISSION = 10;
     /// @notice Keeps the delegation pools
     mapping(address => DelegationPool) public delegationPools;
     // @note maybe this must be part of the ValidatorSet

--- a/contracts/RewardPool/modules/Vesting.sol
+++ b/contracts/RewardPool/modules/Vesting.sol
@@ -128,7 +128,7 @@ abstract contract Vesting is APR {
         uint256 leftWeeks = (leftPeriod + WEEK_MINUS_SECOND) / 1 weeks;
         uint256 bps = 30 * leftWeeks; // 0.3% * left weeks
 
-        return (amount * bps) / 10000;
+        return (amount * bps) / DENOMINATOR;
     }
 
     function _saveEpochRPS(address validator, uint256 rewardPerShare, uint256 epochNumber) internal {
@@ -146,10 +146,10 @@ abstract contract Vesting is APR {
         bool rsi
     ) internal pure returns (uint256) {
         uint256 bonus = (position.base + position.vestBonus);
-        uint256 divider = 10000;
+        uint256 divider = DENOMINATOR;
         if (rsi) {
             bonus = bonus * position.rsiBonus;
-            divider *= 10000;
+            divider *= DENOMINATOR;
         }
 
         return (reward * bonus) / divider / EPOCHS_YEAR;

--- a/contracts/ValidatorSet/ValidatorSet.sol
+++ b/contracts/ValidatorSet/ValidatorSet.sol
@@ -50,7 +50,8 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
         IBLS newBls,
         IRewardPool newRewardPool,
         address governance,
-        address liquidToken
+        address liquidToken,
+        uint256 initialCommission
     ) external initializer onlySystemCall {
         __ValidatorSetBase_init(newBls, newRewardPool);
         __PowerExponent_init();
@@ -58,14 +59,14 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
         __Staking_init(init.minStake, liquidToken);
         __Delegation_init();
         __ReentrancyGuard_init();
-        _initialize(newValidators);
+        _initialize(newValidators, initialCommission);
     }
 
-    function _initialize(ValidatorInit[] calldata newValidators) private {
+    function _initialize(ValidatorInit[] calldata newValidators, uint256 initialCommission) private {
         epochEndBlocks.push(0);
         // set initial validators
         for (uint256 i = 0; i < newValidators.length; i++) {
-            _register(newValidators[i].addr, newValidators[i].signature, newValidators[i].pubkey);
+            _register(newValidators[i].addr, newValidators[i].signature, newValidators[i].pubkey, initialCommission);
             _stake(newValidators[i].addr, newValidators[i].stake);
         }
     }

--- a/contracts/ValidatorSet/modules/Staking/IStaking.sol
+++ b/contracts/ValidatorSet/modules/Staking/IStaking.sol
@@ -18,8 +18,9 @@ interface IStaking {
      * @notice Validates BLS signature with the provided pubkey and registers validators into the set.
      * @param signature Signature to validate message against
      * @param pubkey BLS public key of validator
+     * @param commission The commission rate for the delegators
      */
-    function register(uint256[2] calldata signature, uint256[4] calldata pubkey) external;
+    function register(uint256[2] calldata signature, uint256[4] calldata pubkey, uint256 commission) external;
 
     /**
      * @notice Stakes sent amount.

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -31,6 +31,11 @@ abstract contract Staking is
         _;
     }
 
+    modifier validCommission(uint256 commission) {
+        if (commission > MAX_COMMISSION) revert InvalidCommission(commission);
+        _;
+    }
+
     // _______________ Initializer _______________
 
     function __Staking_init(uint256 newMinStake, address newLiquidToken) internal onlyInitializing {
@@ -39,8 +44,7 @@ abstract contract Staking is
     }
 
     function __Staking_init_unchained(uint256 newMinStake) internal onlyInitializing {
-        // TODO: all requre statements should be replaced with Error
-        require(newMinStake >= 1 ether, "INVALID_MIN_STAKE");
+        if (newMinStake < 1 ether) revert InvalidMinStake(newMinStake);
         minStake = newMinStake;
     }
 
@@ -49,8 +53,7 @@ abstract contract Staking is
     /**
      * @inheritdoc IStaking
      */
-    function setCommission(uint256 newCommission) external onlyValidator {
-        require(newCommission <= MAX_COMMISSION, "INVALID_COMMISSION");
+    function setCommission(uint256 newCommission) external onlyValidator validCommission(newCommission) {
         Validator storage validator = validators[msg.sender];
         validator.commission = newCommission;
 
@@ -106,7 +109,7 @@ abstract contract Staking is
         uint256[2] calldata signature,
         uint256[4] calldata pubkey,
         uint256 commission
-    ) internal {
+    ) internal validCommission(commission) {
         _verifyValidatorRegistration(validator, signature, pubkey);
         validators[validator].blsKey = pubkey;
         validators[validator].active = true;

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -50,8 +50,6 @@ abstract contract Staking is
      */
     function setCommission(uint256 newCommission) external onlyValidator {
         _setCommission(msg.sender, newCommission);
-
-        emit CommissionUpdated(msg.sender, validators[msg.sender].commission, newCommission);
     }
 
     /**
@@ -152,10 +150,12 @@ abstract contract Staking is
         if (amount + currentBalance < minStake) revert StakeRequirement({src: "stake", msg: "STAKE_TOO_LOW"});
     }
 
-    function _setCommission(address validator, uint256 commission) private {
-        if (commission > MAX_COMMISSION) revert InvalidCommission(commission);
+    function _setCommission(address validator, uint256 newCommission) private {
+        if (newCommission > MAX_COMMISSION) revert InvalidCommission(newCommission);
 
-        validators[validator].commission = commission;
+        validators[validator].commission = newCommission;
+
+        emit CommissionUpdated(msg.sender, validators[msg.sender].commission, newCommission);
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -8,3 +8,5 @@ error InvalidSignature(address signer);
 error ZeroAddress();
 error SendFailed();
 error AlreadyRegistered(address validator);
+error InvalidCommission(uint256 commission);
+error InvalidMinStake(uint256 minStake);

--- a/docs/RewardPool/RewardPool.md
+++ b/docs/RewardPool/RewardPool.md
@@ -27,23 +27,6 @@ function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### DELEGATORS_COMMISSION
-
-```solidity
-function DELEGATORS_COMMISSION() external view returns (uint256)
-```
-
-A constant that is used to keep the commission of the delegators
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### DENOMINATOR
 
 ```solidity

--- a/docs/RewardPool/modules/DelegationRewards.md
+++ b/docs/RewardPool/modules/DelegationRewards.md
@@ -27,23 +27,6 @@ function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### DELEGATORS_COMMISSION
-
-```solidity
-function DELEGATORS_COMMISSION() external view returns (uint256)
-```
-
-A constant that is used to keep the commission of the delegators
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### DENOMINATOR
 
 ```solidity

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -1433,6 +1433,38 @@ error DelegateRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### InvalidCommission
+
+```solidity
+error InvalidCommission(uint256 commission)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| commission | uint256 | undefined |
+
+### InvalidMinStake
+
+```solidity
+error InvalidMinStake(uint256 minStake)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| minStake | uint256 | undefined |
+
 ### InvalidSignature
 
 ```solidity

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -469,7 +469,7 @@ function implementation() external view returns (address)
 ### initialize
 
 ```solidity
-function initialize(InitStruct init, ValidatorInit[] newValidators, contract IBLS newBls, contract IRewardPool newRewardPool, address governance, address liquidToken) external nonpayable
+function initialize(InitStruct init, ValidatorInit[] newValidators, contract IBLS newBls, contract IRewardPool newRewardPool, address governance, address liquidToken, uint256 initialCommission) external nonpayable
 ```
 
 
@@ -486,6 +486,7 @@ function initialize(InitStruct init, ValidatorInit[] newValidators, contract IBL
 | newRewardPool | contract IRewardPool | undefined |
 | governance | address | undefined |
 | liquidToken | address | undefined |
+| initialCommission | uint256 | undefined |
 
 ### isVestingManager
 
@@ -636,7 +637,7 @@ function powerExponent() external view returns (uint128 value, uint128 pendingVa
 ### register
 
 ```solidity
-function register(uint256[2] signature, uint256[4] pubkey) external nonpayable
+function register(uint256[2] signature, uint256[4] pubkey, uint256 commission) external nonpayable
 ```
 
 Validates BLS signature with the provided pubkey and registers validators into the set.
@@ -649,6 +650,7 @@ Validates BLS signature with the provided pubkey and registers validators into t
 |---|---|---|
 | signature | uint256[2] | Signature to validate message against |
 | pubkey | uint256[4] | BLS public key of validator |
+| commission | uint256 | The commission rate for the delegators |
 
 ### removeFromWhitelist
 

--- a/docs/ValidatorSet/modules/Staking/IStaking.md
+++ b/docs/ValidatorSet/modules/Staking/IStaking.md
@@ -13,7 +13,7 @@
 ### register
 
 ```solidity
-function register(uint256[2] signature, uint256[4] pubkey) external nonpayable
+function register(uint256[2] signature, uint256[4] pubkey, uint256 commission) external nonpayable
 ```
 
 Validates BLS signature with the provided pubkey and registers validators into the set.
@@ -26,6 +26,7 @@ Validates BLS signature with the provided pubkey and registers validators into t
 |---|---|---|
 | signature | uint256[2] | Signature to validate message against |
 | pubkey | uint256[4] | BLS public key of validator |
+| commission | uint256 | The commission rate for the delegators |
 
 ### setCommission
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -303,7 +303,7 @@ Calculates how much is yet to become withdrawable for account.
 ### register
 
 ```solidity
-function register(uint256[2] signature, uint256[4] pubkey) external nonpayable
+function register(uint256[2] signature, uint256[4] pubkey, uint256 commission) external nonpayable
 ```
 
 Validates BLS signature with the provided pubkey and registers validators into the set.
@@ -316,6 +316,7 @@ Validates BLS signature with the provided pubkey and registers validators into t
 |---|---|---|
 | signature | uint256[2] | Signature to validate message against |
 | pubkey | uint256[4] | BLS public key of validator |
+| commission | uint256 | The commission rate for the delegators |
 
 ### removeFromWhitelist
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -863,6 +863,22 @@ error AlreadyRegistered(address validator)
 |---|---|---|
 | validator | address | undefined |
 
+### InvalidCommission
+
+```solidity
+error InvalidCommission(uint256 commission)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| commission | uint256 | undefined |
+
 ### InvalidSignature
 
 ```solidity

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -8,6 +8,7 @@ export const VALIDATOR_PKCHECK_PRECOMPILE = "0x000000000000000000000000000000000
 export const NATIVE_TRANSFER_PRECOMPILE_GAS = 21000;
 export const VALIDATOR_PKCHECK_PRECOMPILE_GAS = 150000;
 export const CHAIN_ID = 31337;
+export const INITIAL_COMMISSION = ethers.BigNumber.from(10);
 export const MAX_COMMISSION = ethers.BigNumber.from(100);
 export const WEEK = 60 * 60 * 24 * 7;
 export const VESTING_DURATION_WEEKS = 10; // in weeks

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -12,7 +12,7 @@ import {
   RewardPool__factory,
   ValidatorSet__factory,
 } from "../typechain-types";
-import { CHAIN_ID, DOMAIN, SYSTEM, VESTING_DURATION_WEEKS } from "./constants";
+import { CHAIN_ID, DOMAIN, INITIAL_COMMISSION, SYSTEM, VESTING_DURATION_WEEKS } from "./constants";
 import {
   getMaxEpochReward,
   commitEpochs,
@@ -97,7 +97,8 @@ async function initializedValidatorSetStateFixtureFunction(this: Mocha.Context) 
     bls.address,
     rewardPool.address,
     this.signers.governance.address,
-    liquidToken.address
+    liquidToken.address,
+    INITIAL_COMMISSION
   );
 
   return { validatorSet, systemValidatorSet, bls, rewardPool, liquidToken };
@@ -175,13 +176,13 @@ async function registeredValidatorsStateFixtureFunction(this: Mocha.Context) {
 
   await validatorSet
     .connect(this.signers.validators[0])
-    .register(mcl.g1ToHex(validator1signature), mcl.g2ToHex(keyPair.pubkey));
+    .register(mcl.g1ToHex(validator1signature), mcl.g2ToHex(keyPair.pubkey), INITIAL_COMMISSION);
   await validatorSet
     .connect(this.signers.validators[1])
-    .register(mcl.g1ToHex(validator2signature), mcl.g2ToHex(keyPair.pubkey));
+    .register(mcl.g1ToHex(validator2signature), mcl.g2ToHex(keyPair.pubkey), INITIAL_COMMISSION);
   await validatorSet
     .connect(this.signers.validators[2])
-    .register(mcl.g1ToHex(validator3signature), mcl.g2ToHex(keyPair.pubkey));
+    .register(mcl.g1ToHex(validator3signature), mcl.g2ToHex(keyPair.pubkey), INITIAL_COMMISSION);
 
   return { validatorSet, systemValidatorSet, bls, rewardPool, liquidToken };
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -10,7 +10,7 @@ import { ValidatorSet } from "../typechain-types/contracts/ValidatorSet";
 import { RewardPool } from "../typechain-types/contracts/RewardPool";
 import { VestManager } from "../typechain-types/contracts/ValidatorSet/modules/Delegation";
 import { VestManager__factory } from "../typechain-types/factories/contracts/ValidatorSet/modules/Delegation";
-import { CHAIN_ID, DOMAIN, EPOCHS_YEAR, SYSTEM, WEEK } from "./constants";
+import { CHAIN_ID, DOMAIN, EPOCHS_YEAR, INITIAL_COMMISSION, SYSTEM, WEEK } from "./constants";
 
 interface RewardParams {
   timestamp: BigNumber;
@@ -120,7 +120,9 @@ export async function registerValidator(validatorSet: ValidatorSet, governance: 
   const keyPair = mcl.newKeyPair();
   const signature = mcl.signValidatorMessage(DOMAIN, CHAIN_ID, account.address, keyPair.secret).signature;
 
-  const tx = await validatorSet.connect(account).register(mcl.g1ToHex(signature), mcl.g2ToHex(keyPair.pubkey));
+  const tx = await validatorSet
+    .connect(account)
+    .register(mcl.g1ToHex(signature), mcl.g2ToHex(keyPair.pubkey), INITIAL_COMMISSION);
   const txReceipt = await tx.wait();
 
   if (txReceipt.status !== 1) {


### PR DESCRIPTION
- initialize the main validators on the chain with the given commission;
- set the validator's commission when registering and use this in the rewards calculations;
- add new Errors for the commission and the minimum stake;
- revert with error when registering with invalid commission;
- adapt tests;