### PR TITLE
111 fix old tests and add additional for the validator status

### DIFF
--- a/contracts/ValidatorSet/modules/AccessControl/AccessControl.sol
+++ b/contracts/ValidatorSet/modules/AccessControl/AccessControl.sol
@@ -34,7 +34,7 @@ abstract contract AccessControl is IAccessControl, Ownable2StepUpgradeable, Vali
     }
 
     function _addToWhitelist(address account) internal {
-        if (validators[account].status != ValidatorStatus.None) revert("Status must be initial.");
+        if (validators[account].status != ValidatorStatus.None) revert("Previously whitelisted.");
         validators[account].status = ValidatorStatus.Whitelisted;
         emit AddedToWhitelist(account);
     }

--- a/contracts/ValidatorSet/modules/AccessControl/AccessControl.sol
+++ b/contracts/ValidatorSet/modules/AccessControl/AccessControl.sol
@@ -34,6 +34,7 @@ abstract contract AccessControl is IAccessControl, Ownable2StepUpgradeable, Vali
     }
 
     function _addToWhitelist(address account) internal {
+        if (validators[account].status != ValidatorStatus.None) revert("Status must be initial.");
         validators[account].status = ValidatorStatus.Whitelisted;
         emit AddedToWhitelist(account);
     }

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -7,6 +7,5 @@ error DelegateRequirement(string src, string msg);
 error InvalidSignature(address signer);
 error ZeroAddress();
 error SendFailed();
-error AlreadyRegistered(address validator);
 error InvalidCommission(uint256 commission);
 error InvalidMinStake(uint256 minStake);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ import "./big-int-fix.ts";
 dotenv.config();
 
 // eslint-disable-next-line import/first
-import "./tasks";
+// import "./tasks";
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ import "./big-int-fix.ts";
 dotenv.config();
 
 // eslint-disable-next-line import/first
-// import "./tasks";
+import "./tasks";
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/test/ValidatorSet/ValidatorSet.test.ts
+++ b/test/ValidatorSet/ValidatorSet.test.ts
@@ -362,7 +362,7 @@ describe("ValidatorSet", function () {
         );
       });
 
-      it("!!owner should not whitelist user that is already whitelisted", async function () {
+      it("owner should not whitelist user that is already whitelisted", async function () {
         const { validatorSet } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
 
         await expect(
@@ -433,7 +433,7 @@ describe("ValidatorSet", function () {
         );
       });
 
-      it("!!should not be able to whitelist user that is with status Registered/Banned or already Whitelisted", async function () {
+      it("should not be able to whitelist user that is with status Registered/Banned or already Whitelisted", async function () {
         const { validatorSet } = await loadFixture(this.fixtures.whitelistedValidatorsStateFixture);
 
         expect(

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -13,6 +13,13 @@ export const MAX_COMMISSION = ethers.BigNumber.from(100);
 export const WEEK = 60 * 60 * 24 * 7;
 export const VESTING_DURATION_WEEKS = 10; // in weeks
 export const EPOCHS_YEAR = 31500;
+/* eslint-disable no-unused-vars */
+export enum VALIDATOR_STATUS {
+  None = 0,
+  Whitelisted = 1,
+  Registered = 2,
+  Banned = 3,
+}
 
 /// @notice This bytecode is used to mock and return true with any input
 export const alwaysTrueBytecode = "0x600160005260206000F3";


### PR DESCRIPTION
1 - fix test on whitelisting and registration for new logic
2 - add more tests to make sure things work well
3 - add validation on the whitelist function to make sure only people with the initial status 'None' can be whitelisted
4 - remove unused custom error AlreadyRegistered
5 - added enum 'VALIDATOR_STATUS' in the constants for tests, so that the status is more readable