### PR TITLE
optimize rsi

### DIFF
--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -192,12 +192,12 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
         uint256 newBalance = balance + amount;
         if (newBalance < minDelegation) revert DelegateRequirement({src: "vesting", msg: "DELEGATION_TOO_LOW"});
 
-        // @note Potentially use memory variable to avoid get from storage twice
-        if (delegationPositions[validator][delegator].isMaturing()) {
+        VestingPosition memory position = delegationPositions[validator][delegator];
+        if (position.isMaturing()) {
             revert DelegateRequirement({src: "vesting", msg: "POSITION_MATURING"});
         }
 
-        if (delegationPositions[validator][delegator].isActive()) {
+        if (position.isActive()) {
             revert DelegateRequirement({src: "vesting", msg: "POSITION_ACTIVE"});
         }
 

--- a/contracts/RewardPool/modules/Vesting.sol
+++ b/contracts/RewardPool/modules/Vesting.sol
@@ -163,7 +163,7 @@ abstract contract Vesting is APR {
     ) internal pure returns (uint256) {
         uint256 bonus = (position.base + position.vestBonus);
         uint256 divider = DENOMINATOR;
-        if (rsi) {
+        if (rsi && position.rsiBonus != 0) {
             bonus = bonus * position.rsiBonus;
             divider *= divider;
         }

--- a/contracts/RewardPool/modules/Vesting.sol
+++ b/contracts/RewardPool/modules/Vesting.sol
@@ -125,7 +125,7 @@ abstract contract Vesting is APR {
         uint256 durationIncrease = _calculateDurationIncrease(amount, oldBalance, duration);
         positions[staker].duration = duration + durationIncrease;
         positions[staker].end = positions[staker].end + durationIncrease;
-        positions[staker].rsiBonus = 0;
+        positions[staker].rsiBonus = rsi;
     }
 
     /**

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -9,3 +9,5 @@ error ZeroAddress();
 error SendFailed();
 error InvalidCommission(uint256 commission);
 error InvalidMinStake(uint256 minStake);
+error TooLowRSI(uint256 newRSI, uint256 minRSI);
+error TooHighRSI(uint256 newRSI, uint256 maxRSI);

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -9,5 +9,3 @@ error ZeroAddress();
 error SendFailed();
 error InvalidCommission(uint256 commission);
 error InvalidMinStake(uint256 minStake);
-error TooLowRSI(uint256 newRSI, uint256 minRSI);
-error TooHighRSI(uint256 newRSI, uint256 maxRSI);

--- a/docs/RewardPool/RewardPool.md
+++ b/docs/RewardPool/RewardPool.md
@@ -95,23 +95,6 @@ function INITIAL_MACRO_FACTOR() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### INITIAL_RSI_BONUS
-
-```solidity
-function INITIAL_RSI_BONUS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### MANAGER_ROLE
 
 ```solidity
@@ -128,6 +111,40 @@ function MANAGER_ROLE() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### MAX_RSI_BONUS
+
+```solidity
+function MAX_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### MIN_RSI_BONUS
+
+```solidity
+function MIN_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### NATIVE_TOKEN_CONTRACT
 
@@ -548,23 +565,6 @@ function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSiz
 | uptime | Uptime[] | undefined |
 | epochSize | uint256 | undefined |
 
-### getDefaultRSI
-
-```solidity
-function getDefaultRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
-
 ### getDelegationPoolParamsHistory
 
 ```solidity
@@ -675,23 +675,6 @@ function getMaxAPR() external view returns (uint256 nominator, uint256 denominat
 |---|---|---|
 | nominator | uint256 | undefined |
 | denominator | uint256 | undefined |
-
-### getMaxRSI
-
-```solidity
-function getMaxRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
 
 ### getRPSValues
 
@@ -1752,6 +1735,17 @@ error DelegateRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### InvalidRSI
+
+```solidity
+error InvalidRSI()
+```
+
+
+
+
+
+
 ### NoTokensDelegated
 
 ```solidity
@@ -1784,40 +1778,6 @@ error StakeRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
-
-### TooHighRSI
-
-```solidity
-error TooHighRSI(uint256 newRSI, uint256 maxRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| maxRSI | uint256 | undefined |
-
-### TooLowRSI
-
-```solidity
-error TooLowRSI(uint256 newRSI, uint256 minRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| minRSI | uint256 | undefined |
 
 ### Unauthorized
 

--- a/docs/RewardPool/RewardPool.md
+++ b/docs/RewardPool/RewardPool.md
@@ -1785,6 +1785,40 @@ error StakeRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### TooHighRSI
+
+```solidity
+error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| maxRSI | uint256 | undefined |
+
+### TooLowRSI
+
+```solidity
+error TooLowRSI(uint256 newRSI, uint256 minRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| minRSI | uint256 | undefined |
+
 ### Unauthorized
 
 ```solidity

--- a/docs/RewardPool/modules/APR.md
+++ b/docs/RewardPool/modules/APR.md
@@ -95,23 +95,6 @@ function INITIAL_MACRO_FACTOR() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### INITIAL_RSI_BONUS
-
-```solidity
-function INITIAL_RSI_BONUS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### MANAGER_ROLE
 
 ```solidity
@@ -128,6 +111,40 @@ function MANAGER_ROLE() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### MAX_RSI_BONUS
+
+```solidity
+function MAX_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### MIN_RSI_BONUS
+
+```solidity
+function MIN_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### applyMaxReward
 
@@ -168,23 +185,6 @@ function base() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### getDefaultRSI
-
-```solidity
-function getDefaultRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
-
 ### getEpochMaxReward
 
 ```solidity
@@ -224,23 +224,6 @@ function getMaxAPR() external view returns (uint256 nominator, uint256 denominat
 |---|---|---|
 | nominator | uint256 | undefined |
 | denominator | uint256 | undefined |
-
-### getMaxRSI
-
-```solidity
-function getMaxRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
 
 ### getRoleAdmin
 
@@ -564,38 +547,15 @@ event RoleRevoked(bytes32 indexed role, address indexed account, address indexed
 
 ## Errors
 
-### TooHighRSI
+### InvalidRSI
 
 ```solidity
-error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+error InvalidRSI()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| maxRSI | uint256 | undefined |
-
-### TooLowRSI
-
-```solidity
-error TooLowRSI(uint256 newRSI, uint256 minRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| minRSI | uint256 | undefined |
 
 

--- a/docs/RewardPool/modules/APR.md
+++ b/docs/RewardPool/modules/APR.md
@@ -562,3 +562,40 @@ event RoleRevoked(bytes32 indexed role, address indexed account, address indexed
 
 
 
+## Errors
+
+### TooHighRSI
+
+```solidity
+error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| maxRSI | uint256 | undefined |
+
+### TooLowRSI
+
+```solidity
+error TooLowRSI(uint256 newRSI, uint256 minRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| minRSI | uint256 | undefined |
+
+

--- a/docs/RewardPool/modules/DelegationRewards.md
+++ b/docs/RewardPool/modules/DelegationRewards.md
@@ -1559,6 +1559,40 @@ error StakeRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### TooHighRSI
+
+```solidity
+error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| maxRSI | uint256 | undefined |
+
+### TooLowRSI
+
+```solidity
+error TooLowRSI(uint256 newRSI, uint256 minRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| minRSI | uint256 | undefined |
+
 ### Unauthorized
 
 ```solidity

--- a/docs/RewardPool/modules/DelegationRewards.md
+++ b/docs/RewardPool/modules/DelegationRewards.md
@@ -95,23 +95,6 @@ function INITIAL_MACRO_FACTOR() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### INITIAL_RSI_BONUS
-
-```solidity
-function INITIAL_RSI_BONUS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### MANAGER_ROLE
 
 ```solidity
@@ -128,6 +111,40 @@ function MANAGER_ROLE() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### MAX_RSI_BONUS
+
+```solidity
+function MAX_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### MIN_RSI_BONUS
+
+```solidity
+function MIN_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### applyMaxReward
 
@@ -419,23 +436,6 @@ function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSiz
 | uptime | Uptime[] | undefined |
 | epochSize | uint256 | undefined |
 
-### getDefaultRSI
-
-```solidity
-function getDefaultRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
-
 ### getDelegationPoolParamsHistory
 
 ```solidity
@@ -546,23 +546,6 @@ function getMaxAPR() external view returns (uint256 nominator, uint256 denominat
 |---|---|---|
 | nominator | uint256 | undefined |
 | denominator | uint256 | undefined |
-
-### getMaxRSI
-
-```solidity
-function getMaxRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
 
 ### getRPSValues
 
@@ -1542,6 +1525,17 @@ error DelegateRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### InvalidRSI
+
+```solidity
+error InvalidRSI()
+```
+
+
+
+
+
+
 ### StakeRequirement
 
 ```solidity
@@ -1558,40 +1552,6 @@ error StakeRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
-
-### TooHighRSI
-
-```solidity
-error TooHighRSI(uint256 newRSI, uint256 maxRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| maxRSI | uint256 | undefined |
-
-### TooLowRSI
-
-```solidity
-error TooLowRSI(uint256 newRSI, uint256 minRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| minRSI | uint256 | undefined |
 
 ### Unauthorized
 

--- a/docs/RewardPool/modules/StakingRewards.md
+++ b/docs/RewardPool/modules/StakingRewards.md
@@ -1509,4 +1509,38 @@ error StakeRequirement(string src, string msg)
 | src | string | undefined |
 | msg | string | undefined |
 
+### TooHighRSI
+
+```solidity
+error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| maxRSI | uint256 | undefined |
+
+### TooLowRSI
+
+```solidity
+error TooLowRSI(uint256 newRSI, uint256 minRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| minRSI | uint256 | undefined |
+
 

--- a/docs/RewardPool/modules/StakingRewards.md
+++ b/docs/RewardPool/modules/StakingRewards.md
@@ -95,23 +95,6 @@ function INITIAL_MACRO_FACTOR() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### INITIAL_RSI_BONUS
-
-```solidity
-function INITIAL_RSI_BONUS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### MANAGER_ROLE
 
 ```solidity
@@ -128,6 +111,40 @@ function MANAGER_ROLE() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### MAX_RSI_BONUS
+
+```solidity
+function MAX_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### MIN_RSI_BONUS
+
+```solidity
+function MIN_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### applyMaxReward
 
@@ -421,23 +438,6 @@ function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSiz
 | uptime | Uptime[] | undefined |
 | epochSize | uint256 | undefined |
 
-### getDefaultRSI
-
-```solidity
-function getDefaultRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
-
 ### getDelegationPoolParamsHistory
 
 ```solidity
@@ -548,23 +548,6 @@ function getMaxAPR() external view returns (uint256 nominator, uint256 denominat
 |---|---|---|
 | nominator | uint256 | undefined |
 | denominator | uint256 | undefined |
-
-### getMaxRSI
-
-```solidity
-function getMaxRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
 
 ### getRPSValues
 
@@ -1492,6 +1475,17 @@ event ValidatorRewardDistributed(address indexed validator, uint256 amount)
 
 ## Errors
 
+### InvalidRSI
+
+```solidity
+error InvalidRSI()
+```
+
+
+
+
+
+
 ### StakeRequirement
 
 ```solidity
@@ -1508,39 +1502,5 @@ error StakeRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
-
-### TooHighRSI
-
-```solidity
-error TooHighRSI(uint256 newRSI, uint256 maxRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| maxRSI | uint256 | undefined |
-
-### TooLowRSI
-
-```solidity
-error TooLowRSI(uint256 newRSI, uint256 minRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| minRSI | uint256 | undefined |
 
 

--- a/docs/RewardPool/modules/Vesting.md
+++ b/docs/RewardPool/modules/Vesting.md
@@ -875,3 +875,40 @@ event RoleRevoked(bytes32 indexed role, address indexed account, address indexed
 
 
 
+## Errors
+
+### TooHighRSI
+
+```solidity
+error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| maxRSI | uint256 | undefined |
+
+### TooLowRSI
+
+```solidity
+error TooLowRSI(uint256 newRSI, uint256 minRSI)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newRSI | uint256 | undefined |
+| minRSI | uint256 | undefined |
+
+

--- a/docs/RewardPool/modules/Vesting.md
+++ b/docs/RewardPool/modules/Vesting.md
@@ -95,23 +95,6 @@ function INITIAL_MACRO_FACTOR() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### INITIAL_RSI_BONUS
-
-```solidity
-function INITIAL_RSI_BONUS() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### MANAGER_ROLE
 
 ```solidity
@@ -128,6 +111,40 @@ function MANAGER_ROLE() external view returns (bytes32)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bytes32 | undefined |
+
+### MAX_RSI_BONUS
+
+```solidity
+function MAX_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### MIN_RSI_BONUS
+
+```solidity
+function MIN_RSI_BONUS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### applyMaxReward
 
@@ -247,23 +264,6 @@ The vesting positions for every delegator
 | vestBonus | uint256 | undefined |
 | rsiBonus | uint256 | undefined |
 
-### getDefaultRSI
-
-```solidity
-function getDefaultRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
-
 ### getEpochMaxReward
 
 ```solidity
@@ -303,23 +303,6 @@ function getMaxAPR() external view returns (uint256 nominator, uint256 denominat
 |---|---|---|
 | nominator | uint256 | undefined |
 | denominator | uint256 | undefined |
-
-### getMaxRSI
-
-```solidity
-function getMaxRSI() external pure returns (uint256 nominator)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| nominator | uint256 | undefined |
 
 ### getRPSValues
 
@@ -877,38 +860,15 @@ event RoleRevoked(bytes32 indexed role, address indexed account, address indexed
 
 ## Errors
 
-### TooHighRSI
+### InvalidRSI
 
 ```solidity
-error TooHighRSI(uint256 newRSI, uint256 maxRSI)
+error InvalidRSI()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| maxRSI | uint256 | undefined |
-
-### TooLowRSI
-
-```solidity
-error TooLowRSI(uint256 newRSI, uint256 minRSI)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| newRSI | uint256 | undefined |
-| minRSI | uint256 | undefined |
 
 

--- a/test/RewardPool/APR.test.ts
+++ b/test/RewardPool/APR.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable node/no-extraneous-import */
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import {
+  DENOMINATOR,
+  EPOCHS_YEAR,
+  ERRORS,
+  INITIAL_BASE_APR,
+  INITIAL_MACRO_FACTOR,
+  INITIAL_RSI_BONUS,
+  MAX_RSI,
+} from "../constants";
+import { ethers } from "hardhat";
+import { applyMaxReward } from "../helper";
+
+export function RunAPRTests(): void {
+  describe("Initialization", function () {
+    it("should initialize correctly", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const managerRole = await rewardPool.MANAGER_ROLE();
+
+      expect(await rewardPool.hasRole(managerRole, this.signers.system.address)).to.be.true;
+      expect(await rewardPool.base()).to.be.equal(INITIAL_BASE_APR);
+      expect(await rewardPool.macroFactor()).to.be.equal(INITIAL_MACRO_FACTOR);
+      expect(await rewardPool.rsi()).to.be.equal(INITIAL_RSI_BONUS);
+      expect(await rewardPool.EPOCHS_YEAR()).to.be.equal(EPOCHS_YEAR);
+      expect(await rewardPool.DENOMINATOR()).to.be.equal(DENOMINATOR);
+    });
+
+    it("should initialize vesting bonus", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      expect(await rewardPool.getVestingBonus(1)).to.be.equal(6);
+      expect(await rewardPool.getVestingBonus(52)).to.be.equal(2178);
+    });
+
+    it("should get initial RSI", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      expect(await rewardPool.getDefaultRSI()).to.be.equal(INITIAL_RSI_BONUS);
+    });
+
+    it("should get max RSI", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      expect(await rewardPool.getMaxRSI()).to.be.equal(MAX_RSI);
+    });
+
+    it("should get max APR", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      const base = await rewardPool.base();
+      const macroFactor = await rewardPool.macroFactor();
+      const vestingBonus = await rewardPool.getVestingBonus(52);
+      const rsiBonus = await rewardPool.getMaxRSI();
+      const nominator = base.add(vestingBonus).mul(macroFactor).mul(rsiBonus);
+      const denominator = DENOMINATOR.mul(DENOMINATOR).mul(DENOMINATOR);
+
+      const maxAPR = await rewardPool.getMaxAPR();
+      expect(maxAPR.nominator).to.be.equal(nominator);
+      expect(maxAPR.denominator).to.be.equal(denominator);
+    });
+
+    it("should apply max rewards", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      const reward = ethers.BigNumber.from(10);
+      const maxReward = await applyMaxReward(rewardPool, reward);
+
+      expect(await rewardPool.applyMaxReward(reward)).to.be.equal(maxReward);
+    });
+
+    it("should get epoch max reward", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      const totalStaked = ethers.BigNumber.from(1000);
+      const maxAPR = await rewardPool.getMaxAPR();
+      const maxEpochReward = totalStaked.mul(maxAPR.nominator).div(maxAPR.denominator).div(EPOCHS_YEAR);
+
+      expect(await rewardPool.getEpochMaxReward(totalStaked)).to.be.equal(maxEpochReward);
+    });
+  });
+
+  describe("Setters", function () {
+    it("should revert when trying to set base without manager role", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const managerRole = await rewardPool.MANAGER_ROLE();
+
+      await expect(rewardPool.setBase(1500)).to.be.revertedWith(
+        ERRORS.accessControl(this.signers.accounts[0].address.toLocaleLowerCase(), managerRole)
+      );
+    });
+
+    it("should revert when trying to set macro without manager role", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const managerRole = await rewardPool.MANAGER_ROLE();
+
+      await expect(rewardPool.setMacro(10000)).to.be.revertedWith(
+        ERRORS.accessControl(this.signers.accounts[0].address.toLocaleLowerCase(), managerRole)
+      );
+    });
+
+    it("should revert when trying to set rsi without manager role", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const managerRole = await rewardPool.MANAGER_ROLE();
+
+      await expect(rewardPool.setRSI(12000)).to.be.revertedWith(
+        ERRORS.accessControl(this.signers.accounts[0].address.toLocaleLowerCase(), managerRole)
+      );
+    });
+
+    it("should revert when trying to set lower rsi", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const newRSI = 5000;
+
+      await expect(rewardPool.connect(this.signers.system).setRSI(newRSI))
+        .to.be.revertedWithCustomError(rewardPool, "TooLowRSI")
+        .withArgs(newRSI, INITIAL_RSI_BONUS);
+    });
+
+    it("should revert when trying to set higher rsi", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+      const newRSI = 20000;
+      const maxRSI = await rewardPool.getMaxRSI();
+
+      await expect(rewardPool.connect(this.signers.system).setRSI(newRSI))
+        .to.be.revertedWithCustomError(rewardPool, "TooHighRSI")
+        .withArgs(newRSI, maxRSI);
+    });
+
+    it("should set base", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      await rewardPool.connect(this.signers.system).setBase(1500);
+
+      expect(await rewardPool.base()).to.be.equal(1500);
+    });
+
+    it("should set macro", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      await rewardPool.connect(this.signers.system).setMacro(10000);
+
+      expect(await rewardPool.macroFactor()).to.be.equal(10000);
+    });
+
+    it("should set rsi", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
+
+      await rewardPool.connect(this.signers.system).setRSI(12000);
+
+      expect(await rewardPool.rsi()).to.be.equal(12000);
+    });
+  });
+}

--- a/test/RewardPool/RewardPool.test.ts
+++ b/test/RewardPool/RewardPool.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import * as hre from "hardhat";
 import { expect } from "chai";
 
-import { EPOCHS_YEAR, VESTING_DURATION_WEEKS, WEEK } from "../constants";
+import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
 import {
   calculateExpectedReward,
   commitEpoch,
@@ -460,7 +460,7 @@ export function RunVestedDelegateClaimTests(): void {
 
       // calculate max reward
       const maxVestBonus = await rewardPool.getVestingBonus(52);
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
 
       // enter the maturing state
@@ -504,7 +504,7 @@ export function RunVestedDelegateClaimTests(): void {
 
       // calculate max reward
       const maxVestBonus = await rewardPool.getVestingBonus(52);
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
 
       // ensure maturing has finished
@@ -580,14 +580,14 @@ export function RunVestedDelegateClaimTests(): void {
       const topUpReward = (await rewardPool.getRawDelegatorReward(delegatedValidator.address, vestManager.address)).sub(
         baseReward
       );
+
       // no rsi because top-up is used
-      const defaultRSI = await rewardPool.getDefaultRSI();
-      const expectedTopUpReward = await calculateExpectedReward(base, vestBonus, defaultRSI, topUpReward);
+      const expectedTopUpReward = await calculateExpectedReward(base, vestBonus, MIN_RSI_BONUS, topUpReward);
       const expectedReward = expectedBaseReward.add(expectedTopUpReward);
 
       // calculate max reward
       const maxVestBonus = await rewardPool.getVestingBonus(52);
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxBaseReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
       const maxTopUpReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, topUpReward);
       const maxReward = maxBaseReward.add(maxTopUpReward);
@@ -636,7 +636,6 @@ export function RunVestedDelegateClaimTests(): void {
       const base = await rewardPool.base();
       const vestBonus = await rewardPool.getVestingBonus(1);
       const rsi = await rewardPool.rsi();
-      const defaultRSI = await rewardPool.getDefaultRSI();
       const expectedBaseReward = await calculateExpectedReward(base, vestBonus, rsi, baseReward);
 
       // top-up
@@ -654,12 +653,12 @@ export function RunVestedDelegateClaimTests(): void {
       const topUpReward = (await rewardPool.getRawDelegatorReward(delegatedValidator.address, vestManager.address)).sub(
         baseReward
       );
-      const expectedTopUpReward = await calculateExpectedReward(base, vestBonus, defaultRSI, topUpReward);
+      const expectedTopUpReward = await calculateExpectedReward(base, vestBonus, MIN_RSI_BONUS, topUpReward);
 
       const expectedReward = expectedBaseReward.add(expectedTopUpReward);
 
       // calculate max reward
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxVestBonus = await rewardPool.getVestingBonus(52);
       const maxBaseReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
       const maxTopUpReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, topUpReward);
@@ -879,7 +878,7 @@ export function RunVestedDelegateClaimTests(): void {
       const rsi = await rewardPool.rsi();
       const expectedBaseReward = await calculateExpectedReward(base, vestBonus, rsi, baseReward);
 
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxVestBonus = await rewardPool.getVestingBonus(52);
       const maxBaseReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
 
@@ -941,7 +940,7 @@ export function RunVestedDelegateClaimTests(): void {
       const rsi = await rewardPool.rsi();
       const reward = await calculateExpectedReward(base, vestBonus, rsi, baseReward);
 
-      const maxRSI = await rewardPool.getMaxRSI();
+      const maxRSI = await rewardPool.MAX_RSI_BONUS();
       const maxVestBonus = await rewardPool.getVestingBonus(52);
       const maxBaseReward = await calculateExpectedReward(base, maxVestBonus, maxRSI, baseReward);
 

--- a/test/ValidatorSet/Staking.test.ts
+++ b/test/ValidatorSet/Staking.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import * as hre from "hardhat";
 
-import { WEEK, VESTING_DURATION_WEEKS } from "../constants";
+import { WEEK, VESTING_DURATION_WEEKS, INITIAL_RSI_BONUS } from "../constants";
 import { calculatePenalty, commitEpochs, getValidatorReward, registerValidator } from "../helper";
 import { RunStakingClaimTests } from "../RewardPool/RewardPool.test";
 
@@ -199,7 +199,7 @@ export function RunStakingTests(): void {
 
         expect(vestingData.duration, "duration").to.be.equal(vestingDuration * 2);
         expect(vestingData.end, "end").to.be.equal(vestingData.start.add(vestingDuration * 2));
-        expect(vestingData.rsiBonus, "rsiBonus").to.be.equal(0);
+        expect(vestingData.rsiBonus, "rsiBonus").to.be.equal(INITIAL_RSI_BONUS);
 
         await commitEpochs(
           systemValidatorSet,

--- a/test/ValidatorSet/Staking.test.ts
+++ b/test/ValidatorSet/Staking.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import * as hre from "hardhat";
 
-import { WEEK, VESTING_DURATION_WEEKS, INITIAL_RSI_BONUS } from "../constants";
+import { WEEK, VESTING_DURATION_WEEKS, MIN_RSI_BONUS } from "../constants";
 import { calculatePenalty, commitEpochs, getValidatorReward, registerValidator } from "../helper";
 import { RunStakingClaimTests } from "../RewardPool/RewardPool.test";
 
@@ -199,7 +199,7 @@ export function RunStakingTests(): void {
 
         expect(vestingData.duration, "duration").to.be.equal(vestingDuration * 2);
         expect(vestingData.end, "end").to.be.equal(vestingData.start.add(vestingDuration * 2));
-        expect(vestingData.rsiBonus, "rsiBonus").to.be.equal(INITIAL_RSI_BONUS);
+        expect(vestingData.rsiBonus, "rsiBonus").to.be.equal(MIN_RSI_BONUS);
 
         await commitEpochs(
           systemValidatorSet,

--- a/test/ValidatorSet/ValidatorSet.test.ts
+++ b/test/ValidatorSet/ValidatorSet.test.ts
@@ -10,6 +10,7 @@ import { commitEpoch, generateValidatorBls, initializeContext } from "../helper"
 import { RunSystemTests } from "./System.test";
 import { RunStakingTests } from "./Staking.test";
 import { RunDelegationTests } from "./Delegation.test";
+import { RunAPRTests } from "../RewardPool/APR.test";
 
 describe("ValidatorSet", function () {
   before(async function () {
@@ -323,6 +324,10 @@ describe("ValidatorSet", function () {
       expect(storedEpoch.startBlock).to.equal(hre.ethers.constants.Zero);
       expect(storedEpoch.endBlock).to.equal(hre.ethers.constants.Zero);
       expect(storedEpoch.epochRoot).to.equal(hre.ethers.constants.HashZero);
+    });
+
+    describe("APR", function () {
+      RunAPRTests();
     });
 
     describe("Whitelist", function () {

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -12,15 +12,12 @@ export const INITIAL_COMMISSION = ethers.BigNumber.from(10);
 export const MAX_COMMISSION = ethers.BigNumber.from(100);
 export const WEEK = 60 * 60 * 24 * 7;
 export const VESTING_DURATION_WEEKS = 10; // in weeks
-export const EPOCHS_YEAR = 31500;
-export const DENOMINATOR = 10000;
-/* eslint-disable no-unused-vars */
-export enum VALIDATOR_STATUS {
-  None = 0,
-  Whitelisted = 1,
-  Registered = 2,
-  Banned = 3,
-}
+export const EPOCHS_YEAR = ethers.BigNumber.from(31500);
+export const INITIAL_BASE_APR = ethers.BigNumber.from(500);
+export const INITIAL_MACRO_FACTOR = ethers.BigNumber.from(7500);
+export const INITIAL_RSI_BONUS = ethers.BigNumber.from(10000);
+export const DENOMINATOR = ethers.BigNumber.from(10000);
+export const MAX_RSI = ethers.BigNumber.from(15000);
 
 /// @notice This bytecode is used to mock and return true with any input
 export const alwaysTrueBytecode = "0x600160005260206000F3";
@@ -28,3 +25,9 @@ export const alwaysTrueBytecode = "0x600160005260206000F3";
 export const alwaysFalseBytecode = "0x60206000F3";
 /// @notice This bytecode is used to mock and revert with any input
 export const alwaysRevertBytecode = "0x60006000FD";
+
+export const ERRORS = {
+  accessControl: (account: string, role: string) => {
+    return `AccessControl: account ${account} is missing role ${role}`;
+  },
+};

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -18,6 +18,13 @@ export const INITIAL_MACRO_FACTOR = ethers.BigNumber.from(7500);
 export const MIN_RSI_BONUS = ethers.BigNumber.from(10000);
 export const MAX_RSI_BONUS = ethers.BigNumber.from(17000);
 export const DENOMINATOR = ethers.BigNumber.from(10000);
+/* eslint-disable no-unused-vars */
+export enum VALIDATOR_STATUS {
+  None = 0,
+  Whitelisted = 1,
+  Registered = 2,
+  Banned = 3,
+}
 
 /// @notice This bytecode is used to mock and return true with any input
 export const alwaysTrueBytecode = "0x600160005260206000F3";

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -15,9 +15,9 @@ export const VESTING_DURATION_WEEKS = 10; // in weeks
 export const EPOCHS_YEAR = ethers.BigNumber.from(31500);
 export const INITIAL_BASE_APR = ethers.BigNumber.from(500);
 export const INITIAL_MACRO_FACTOR = ethers.BigNumber.from(7500);
-export const INITIAL_RSI_BONUS = ethers.BigNumber.from(10000);
+export const MIN_RSI_BONUS = ethers.BigNumber.from(10000);
+export const MAX_RSI_BONUS = ethers.BigNumber.from(17000);
 export const DENOMINATOR = ethers.BigNumber.from(10000);
-export const MAX_RSI = ethers.BigNumber.from(15000);
 
 /// @notice This bytecode is used to mock and return true with any input
 export const alwaysTrueBytecode = "0x600160005260206000F3";

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -12,7 +12,7 @@ import {
   RewardPool__factory,
   ValidatorSet__factory,
 } from "../typechain-types";
-import { CHAIN_ID, DOMAIN, INITIAL_COMMISSION, SYSTEM, VESTING_DURATION_WEEKS } from "./constants";
+import { CHAIN_ID, DOMAIN, INITIAL_COMMISSION, MIN_RSI_BONUS, SYSTEM, VESTING_DURATION_WEEKS } from "./constants";
 import {
   getMaxEpochReward,
   commitEpochs,
@@ -191,6 +191,8 @@ async function stakedValidatorsStateFixtureFunction(this: Mocha.Context) {
     this.fixtures.registeredValidatorsStateFixture
   );
 
+  // set the rsi to the minimum value
+  await rewardPool.connect(this.signers.system).setRSI(MIN_RSI_BONUS);
   await validatorSet.connect(this.signers.validators[0]).stake({ value: this.minStake.mul(2) });
   await validatorSet.connect(this.signers.validators[1]).stake({ value: this.minStake.mul(2) });
 

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -249,12 +249,7 @@ export async function calculateExpectedReward(
   reward: BigNumber
 ) {
   // calculate expected reward based on the given apr factors
-  return base
-    .add(vestBonus)
-    .mul(rsi)
-    .mul(reward)
-    .div(DENOMINATOR * DENOMINATOR)
-    .div(EPOCHS_YEAR);
+  return base.add(vestBonus).mul(rsi).mul(reward).div(DENOMINATOR.mul(DENOMINATOR)).div(EPOCHS_YEAR);
 }
 
 export async function applyMaxReward(rewardPool: RewardPool, reward: BigNumber) {
@@ -263,12 +258,7 @@ export async function applyMaxReward(rewardPool: RewardPool, reward: BigNumber) 
   const vestBonus = await rewardPool.getVestingBonus(52);
 
   // calculate expected reward
-  return base
-    .add(vestBonus)
-    .mul(rsi)
-    .mul(reward)
-    .div(DENOMINATOR * DENOMINATOR)
-    .div(EPOCHS_YEAR);
+  return base.add(vestBonus).mul(rsi).mul(reward).div(DENOMINATOR.mul(DENOMINATOR)).div(EPOCHS_YEAR);
 }
 
 export async function applyCustomReward(
@@ -284,7 +274,7 @@ export async function applyCustomReward(
   let divider = DENOMINATOR;
   if (rsi) {
     bonus = bonus.mul(position.rsiBonus);
-    divider **= 2;
+    divider = divider.mul(DENOMINATOR);
   }
 
   return reward.mul(bonus).div(divider).div(EPOCHS_YEAR);

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -272,7 +272,7 @@ export async function applyCustomReward(
 
   let bonus = position.base.add(position.vestBonus);
   let divider = DENOMINATOR;
-  if (rsi) {
+  if (rsi && !position.rsiBonus.isZero()) {
     bonus = bonus.mul(position.rsiBonus);
     divider = divider.mul(DENOMINATOR);
   }


### PR DESCRIPTION
- create new custom error for the rsi;
- ensure that the new RSI is between the range - 0% to 50%;
- set initial rsi to 0 and also if one tries to set rsi lower than 10000, then set it to 0;
- set initial rsi bonus on stake position;
- create the max rsi as a constant instead of a function;
- adapt tests and create new ones for the APR;