### PR TITLE
124 add functions in the contracts that allow minstake and mindelegation to be changeable by the governor

### DIFF
--- a/contracts/RewardPool/IRewardPool.sol
+++ b/contracts/RewardPool/IRewardPool.sol
@@ -250,4 +250,11 @@ interface IRewardPool {
      * @return Amount delegated (in MATIC wei)
      */
     function totalDelegationOf(address validator) external view returns (uint256);
+
+    /**
+     * @dev Should be called only by the Governance.
+     * @notice Changes the minDelegationAmount
+     * @param newMinDelegation New minimum delegation amount
+     */
+    function changeMinDelegation(uint256 newMinDelegation) external;
 }

--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -10,8 +10,6 @@ import "./../libs/VestingPositionLib.sol";
 
 import "./../../common/Errors.sol";
 
-error InvalidMinDelegation();
-
 abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawal {
     using DelegationPoolLib for DelegationPool;
     using VestingPositionLib for VestingPosition;
@@ -23,6 +21,8 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     // @note maybe this must be part of the ValidatorSet
     /// @notice The minimum delegation amount to be delegated
     uint256 public minDelegation;
+
+    error InvalidMinDelegation();
 
     // _______________ Initializer _______________
 

--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -10,6 +10,8 @@ import "./../libs/VestingPositionLib.sol";
 
 import "./../../common/Errors.sol";
 
+error InvalidMinDelegation();
+
 abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawal {
     using DelegationPoolLib for DelegationPool;
     using VestingPositionLib for VestingPosition;

--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -14,6 +14,8 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     using DelegationPoolLib for DelegationPool;
     using VestingPositionLib for VestingPosition;
 
+    /// @notice A constant for the minimum delegation limit
+    uint256 public constant MIN_DELEGATION_LIMIT = 1 ether;
     /// @notice Keeps the delegation pools
     mapping(address => DelegationPool) public delegationPools;
     // @note maybe this must be part of the ValidatorSet
@@ -410,9 +412,7 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     // _______________ Private functions _______________
 
     function _changeMinDelegation(uint256 newMinDelegation) private {
-        if (newMinDelegation < 1 ether) { 
-            revert InvalidMinDelegation(newMinDelegation);
-        }
+        if (newMinDelegation < MIN_DELEGATION_LIMIT) revert InvalidMinDelegation();
         minDelegation = newMinDelegation;
     }
 

--- a/contracts/RewardPool/modules/DelegationRewards.sol
+++ b/contracts/RewardPool/modules/DelegationRewards.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "./../RewardPoolBase.sol";
 import "./Vesting.sol";
-import "./../../common/Errors.sol";
 import "./RewardsWithdrawal.sol";
 
+import "./../RewardPoolBase.sol";
 import "./../libs/DelegationPoolLib.sol";
 import "./../libs/VestingPositionLib.sol";
+
+import "./../../common/Errors.sol";
 
 abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawal {
     using DelegationPoolLib for DelegationPool;
@@ -26,9 +27,7 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     }
 
     function __DelegationRewards_init_unchained(uint256 newMinDelegation) internal onlyInitializing {
-        // TODO: all requre statements should be replaced with Error
-        require(newMinDelegation >= 1 ether, "INVALID_MIN_DELEGATION");
-        minDelegation = newMinDelegation;
+        _changeMinDelegation(newMinDelegation);
     }
 
     // _______________ External functions _______________
@@ -368,6 +367,13 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
         emit PositionRewardClaimed(msg.sender, validator, sumReward);
     }
 
+    /**
+     * @inheritdoc IRewardPool
+     */
+    function changeMinDelegation(uint256 newMinDelegation) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _changeMinDelegation(newMinDelegation);
+    }
+
     // _______________ Public functions _______________
 
     /**
@@ -402,6 +408,13 @@ abstract contract DelegationRewards is RewardPoolBase, Vesting, RewardsWithdrawa
     }
 
     // _______________ Private functions _______________
+
+    function _changeMinDelegation(uint256 newMinDelegation) private {
+        if (newMinDelegation < 1 ether) { 
+            revert InvalidMinDelegation(newMinDelegation);
+        }
+        minDelegation = newMinDelegation;
+    }
 
     function _noRewardConditions(VestingPosition memory position) private view returns (bool) {
         // If still unused position, there is no reward

--- a/contracts/ValidatorSet/modules/Staking/IStaking.sol
+++ b/contracts/ValidatorSet/modules/Staking/IStaking.sol
@@ -7,6 +7,9 @@ interface IStaking {
     event Staked(address indexed validator, uint256 amount);
     event Unstaked(address indexed validator, uint256 amount);
 
+    error InvalidCommission(uint256 commission);
+    error InvalidMinStake();
+
     /**
      * @notice Sets commission for validator.
      * @param newCommission New commission (100 = 100%)

--- a/contracts/ValidatorSet/modules/Staking/IStaking.sol
+++ b/contracts/ValidatorSet/modules/Staking/IStaking.sol
@@ -37,4 +37,11 @@ interface IStaking {
      * @param amount Amount to unstake
      */
     function unstake(uint256 amount) external;
+
+    /**
+     * @dev Should be called by the Governance.
+     * @notice Changes minimum stake required for validators.
+     * @param newMinStake New minimum stake
+     */
+    function changeMinStake(uint256 newMinStake) external;
 }

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -38,8 +38,8 @@ abstract contract Staking is
     }
 
     function __Staking_init_unchained(uint256 newMinStake) internal onlyInitializing {
-        if (newMinStake < 1 ether) revert InvalidMinStake(newMinStake);
-        minStake = newMinStake;
+        _changeMinStake(newMinStake);
+
     }
 
     // _______________ External functions _______________
@@ -89,6 +89,13 @@ abstract contract Staking is
         _registerWithdrawal(msg.sender, amountToWithdraw);
 
         emit Unstaked(msg.sender, amount);
+    }
+
+    /**
+     * @inheritdoc IStaking
+     */
+    function changeMinStake(uint256 newMinStake) external onlyOwner {
+        _changeMinStake(newMinStake);
     }
 
     // _______________ Internal functions _______________
@@ -143,6 +150,11 @@ abstract contract Staking is
         validators[validator].commission = newCommission;
 
         emit CommissionUpdated(validator, newCommission);
+    }
+
+    function _changeMinStake(uint256 newMinStake) private {
+        if (newMinStake < 1 ether) revert InvalidMinStake(newMinStake);
+        minStake = newMinStake;
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -8,8 +8,6 @@ import "./BalanceState.sol";
 import "./../Withdrawal/Withdrawal.sol";
 
 // TODO: An optimization we can do is keeping only once the general apr params for a block so we don' have to keep them for every single user
-error InvalidCommission(uint256 commission);
-error InvalidMinStake();
 
 abstract contract Staking is
     IStaking,

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -17,6 +17,8 @@ abstract contract Staking is
     LiquidStaking,
     StateSyncer
 {
+    /// @notice A constant for the minimum stake limit
+    uint256 public constant MIN_STAKE_LIMIT = 1 ether;
     /// @notice A constant for the maximum comission a validator can receive from the delegator's rewards
     uint256 public constant MAX_COMMISSION = 100;
     /// @notice A state variable to keep the minimum amount of stake
@@ -153,7 +155,7 @@ abstract contract Staking is
     }
 
     function _changeMinStake(uint256 newMinStake) private {
-        if (newMinStake < 1 ether) revert InvalidMinStake(newMinStake);
+        if (newMinStake < MIN_STAKE_LIMIT) revert InvalidMinStake();
         minStake = newMinStake;
     }
 

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -8,6 +8,8 @@ import "./BalanceState.sol";
 import "./../Withdrawal/Withdrawal.sol";
 
 // TODO: An optimization we can do is keeping only once the general apr params for a block so we don' have to keep them for every single user
+error InvalidCommission(uint256 commission);
+error InvalidMinStake();
 
 abstract contract Staking is
     IStaking,

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -9,3 +9,4 @@ error ZeroAddress();
 error SendFailed();
 error InvalidCommission(uint256 commission);
 error InvalidMinStake(uint256 minStake);
+error InvalidMinDelegation(uint256 minDelegation);

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -7,6 +7,3 @@ error DelegateRequirement(string src, string msg);
 error InvalidSignature(address signer);
 error ZeroAddress();
 error SendFailed();
-error InvalidCommission(uint256 commission);
-error InvalidMinStake();
-error InvalidMinDelegation();

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -8,5 +8,5 @@ error InvalidSignature(address signer);
 error ZeroAddress();
 error SendFailed();
 error InvalidCommission(uint256 commission);
-error InvalidMinStake(uint256 minStake);
-error InvalidMinDelegation(uint256 minDelegation);
+error InvalidMinStake();
+error InvalidMinDelegation();

--- a/docs/RewardPool/IRewardPool.md
+++ b/docs/RewardPool/IRewardPool.md
@@ -81,6 +81,22 @@ Returns the total reward that is generated for a position
 |---|---|---|
 | reward | uint256 | for the delegator |
 
+### changeMinDelegation
+
+```solidity
+function changeMinDelegation(uint256 newMinDelegation) external nonpayable
+```
+
+Changes the minDelegationAmount
+
+*Should be called only by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinDelegation | uint256 | New minimum delegation amount |
+
 ### claimDelegatorReward
 
 ```solidity

--- a/docs/RewardPool/RewardPool.md
+++ b/docs/RewardPool/RewardPool.md
@@ -383,6 +383,22 @@ Returns the total reward that is generated for a position
 |---|---|---|
 | reward | uint256 | for the delegator |
 
+### changeMinDelegation
+
+```solidity
+function changeMinDelegation(uint256 newMinDelegation) external nonpayable
+```
+
+Changes the minDelegationAmount
+
+*Should be called only by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinDelegation | uint256 | New minimum delegation amount |
+
 ### claimDelegatorReward
 
 ```solidity
@@ -1734,6 +1750,22 @@ error DelegateRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
+
+### InvalidMinDelegation
+
+```solidity
+error InvalidMinDelegation(uint256 minDelegation)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| minDelegation | uint256 | undefined |
 
 ### InvalidRSI
 

--- a/docs/RewardPool/RewardPool.md
+++ b/docs/RewardPool/RewardPool.md
@@ -129,6 +129,23 @@ function MAX_RSI_BONUS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### MIN_DELEGATION_LIMIT
+
+```solidity
+function MIN_DELEGATION_LIMIT() external view returns (uint256)
+```
+
+A constant for the minimum delegation limit
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### MIN_RSI_BONUS
 
 ```solidity
@@ -1754,18 +1771,13 @@ error DelegateRequirement(string src, string msg)
 ### InvalidMinDelegation
 
 ```solidity
-error InvalidMinDelegation(uint256 minDelegation)
+error InvalidMinDelegation()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| minDelegation | uint256 | undefined |
 
 ### InvalidRSI
 

--- a/docs/RewardPool/RewardPoolBase.md
+++ b/docs/RewardPool/RewardPoolBase.md
@@ -81,6 +81,22 @@ Returns the total reward that is generated for a position
 |---|---|---|
 | reward | uint256 | for the delegator |
 
+### changeMinDelegation
+
+```solidity
+function changeMinDelegation(uint256 newMinDelegation) external nonpayable
+```
+
+Changes the minDelegationAmount
+
+*Should be called only by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinDelegation | uint256 | New minimum delegation amount |
+
 ### claimDelegatorReward
 
 ```solidity

--- a/docs/RewardPool/modules/DelegationRewards.md
+++ b/docs/RewardPool/modules/DelegationRewards.md
@@ -281,6 +281,22 @@ Returns the total reward that is generated for a position
 |---|---|---|
 | reward | uint256 | for the delegator |
 
+### changeMinDelegation
+
+```solidity
+function changeMinDelegation(uint256 newMinDelegation) external nonpayable
+```
+
+Changes the minDelegationAmount
+
+*Should be called only by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinDelegation | uint256 | New minimum delegation amount |
+
 ### claimDelegatorReward
 
 ```solidity
@@ -1524,6 +1540,22 @@ error DelegateRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
+
+### InvalidMinDelegation
+
+```solidity
+error InvalidMinDelegation(uint256 minDelegation)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| minDelegation | uint256 | undefined |
 
 ### InvalidRSI
 

--- a/docs/RewardPool/modules/DelegationRewards.md
+++ b/docs/RewardPool/modules/DelegationRewards.md
@@ -129,6 +129,23 @@ function MAX_RSI_BONUS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### MIN_DELEGATION_LIMIT
+
+```solidity
+function MIN_DELEGATION_LIMIT() external view returns (uint256)
+```
+
+A constant for the minimum delegation limit
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### MIN_RSI_BONUS
 
 ```solidity
@@ -1544,18 +1561,13 @@ error DelegateRequirement(string src, string msg)
 ### InvalidMinDelegation
 
 ```solidity
-error InvalidMinDelegation(uint256 minDelegation)
+error InvalidMinDelegation()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| minDelegation | uint256 | undefined |
 
 ### InvalidRSI
 

--- a/docs/RewardPool/modules/StakingRewards.md
+++ b/docs/RewardPool/modules/StakingRewards.md
@@ -281,6 +281,22 @@ Returns the total reward that is generated for a position
 |---|---|---|
 | reward | uint256 | for the delegator |
 
+### changeMinDelegation
+
+```solidity
+function changeMinDelegation(uint256 newMinDelegation) external nonpayable
+```
+
+Changes the minDelegationAmount
+
+*Should be called only by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinDelegation | uint256 | New minimum delegation amount |
+
 ### claimDelegatorReward
 
 ```solidity

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -246,16 +246,6 @@ function bls() external view returns (contract IBLS)
 |---|---|---|
 | _0 | contract IBLS | undefined |
 
-### changeWithdrawalWaitPeriod
-
-```solidity
-function changeWithdrawalWaitPeriod(uint256 newWaitPeriod) external nonpayable
-```
-
-Changes the withdrawal wait period.
-
-*This function should be called only by the Governed contract.*
-
 ### changeMinStake
 
 ```solidity
@@ -270,8 +260,23 @@ Changes minimum stake required for validators.
 
 | Name | Type | Description |
 |---|---|---|
-| newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
 | newMinStake | uint256 | New minimum stake |
+
+### changeWithdrawalWaitPeriod
+
+```solidity
+function changeWithdrawalWaitPeriod(uint256 newWaitPeriod) external nonpayable
+```
+
+Changes the withdrawal wait period.
+
+*This function should be called only by the Governed contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
 
 ### commitEpoch
 

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -44,6 +44,23 @@ A constant for the maximum comission a validator can receive from the delegator&
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### MIN_STAKE_LIMIT
+
+```solidity
+function MIN_STAKE_LIMIT() external view returns (uint256)
+```
+
+A constant for the minimum stake limit
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### NATIVE_TOKEN_CONTRACT
 
 ```solidity
@@ -1444,18 +1461,13 @@ error InvalidCommission(uint256 commission)
 ### InvalidMinStake
 
 ```solidity
-error InvalidMinStake(uint256 minStake)
+error InvalidMinStake()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| minStake | uint256 | undefined |
 
 ### InvalidSignature
 

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -239,11 +239,22 @@ Changes the withdrawal wait period.
 
 *This function should be called only by the Governed contract.*
 
+### changeMinStake
+
+```solidity
+function changeMinStake(uint256 newMinStake) external nonpayable
+```
+
+Changes minimum stake required for validators.
+
+*Should be called by the Governance.*
+
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
+| newMinStake | uint256 | New minimum stake |
 
 ### commitEpoch
 

--- a/docs/ValidatorSet/modules/Staking/IStaking.md
+++ b/docs/ValidatorSet/modules/Staking/IStaking.md
@@ -177,3 +177,33 @@ event Unstaked(address indexed validator, uint256 amount)
 
 
 
+## Errors
+
+### InvalidCommission
+
+```solidity
+error InvalidCommission(uint256 commission)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| commission | uint256 | undefined |
+
+### InvalidMinStake
+
+```solidity
+error InvalidMinStake()
+```
+
+
+
+
+
+
+

--- a/docs/ValidatorSet/modules/Staking/IStaking.md
+++ b/docs/ValidatorSet/modules/Staking/IStaking.md
@@ -10,6 +10,22 @@
 
 ## Methods
 
+### changeMinStake
+
+```solidity
+function changeMinStake(uint256 newMinStake) external nonpayable
+```
+
+Changes minimum stake required for validators.
+
+*Should be called by the Governance.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newMinStake | uint256 | New minimum stake |
+
 ### register
 
 ```solidity

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -137,11 +137,22 @@ Changes the withdrawal wait period.
 
 *This function should be called only by the Governed contract.*
 
+### changeMinStake
+
+```solidity
+function changeMinStake(uint256 newMinStake) external nonpayable
+```
+
+Changes minimum stake required for validators.
+
+*Should be called by the Governance.*
+
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
+| newMinStake | uint256 | New minimum stake |
 
 ### currentEpochId
 
@@ -859,6 +870,22 @@ error InvalidCommission(uint256 commission)
 | Name | Type | Description |
 |---|---|---|
 | commission | uint256 | undefined |
+
+### InvalidMinStake
+
+```solidity
+error InvalidMinStake(uint256 minStake)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| minStake | uint256 | undefined |
 
 ### InvalidSignature
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -144,16 +144,6 @@ function bls() external view returns (contract IBLS)
 |---|---|---|
 | _0 | contract IBLS | undefined |
 
-### changeWithdrawalWaitPeriod
-
-```solidity
-function changeWithdrawalWaitPeriod(uint256 newWaitPeriod) external nonpayable
-```
-
-Changes the withdrawal wait period.
-
-*This function should be called only by the Governed contract.*
-
 ### changeMinStake
 
 ```solidity
@@ -168,8 +158,23 @@ Changes minimum stake required for validators.
 
 | Name | Type | Description |
 |---|---|---|
-| newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
 | newMinStake | uint256 | New minimum stake |
+
+### changeWithdrawalWaitPeriod
+
+```solidity
+function changeWithdrawalWaitPeriod(uint256 newWaitPeriod) external nonpayable
+```
+
+Changes the withdrawal wait period.
+
+*This function should be called only by the Governed contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newWaitPeriod | uint256 | The new withdrawal wait period. MUST be longer than a single  epoch (in some realistic worst-case scenario) in case somebody&#39;s stake needs to be penalized. |
 
 ### currentEpochId
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -44,6 +44,23 @@ A constant for the maximum comission a validator can receive from the delegator&
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### MIN_STAKE_LIMIT
+
+```solidity
+function MIN_STAKE_LIMIT() external view returns (uint256)
+```
+
+A constant for the minimum stake limit
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### WITHDRAWAL_WAIT_PERIOD
 
 ```solidity
@@ -874,18 +891,13 @@ error InvalidCommission(uint256 commission)
 ### InvalidMinStake
 
 ```solidity
-error InvalidMinStake(uint256 minStake)
+error InvalidMinStake()
 ```
 
 
 
 
 
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| minStake | uint256 | undefined |
 
 ### InvalidSignature
 

--- a/test/LiquidityToken/LiquidityToken.test.ts
+++ b/test/LiquidityToken/LiquidityToken.test.ts
@@ -36,7 +36,7 @@ describe("LiquidityToken", async function () {
     return { token };
   }
 
-  it("should have default admin  role set", async () => {
+  it("should have default admin role set", async () => {
     const { token } = await loadFixture(deployFixture);
     expect(await token.DEFAULT_ADMIN_ROLE()).equal(governerRole);
   });

--- a/test/RewardPool/APR.test.ts
+++ b/test/RewardPool/APR.test.ts
@@ -19,7 +19,7 @@ export function RunAPRTests(): void {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
       const managerRole = await rewardPool.MANAGER_ROLE();
 
-      expect(await rewardPool.hasRole(managerRole, this.signers.system.address)).to.be.true;
+      expect(await rewardPool.hasRole(managerRole, this.signers.governance.address)).to.be.true;
       expect(await rewardPool.base()).to.be.equal(INITIAL_BASE_APR);
       expect(await rewardPool.macroFactor()).to.be.equal(INITIAL_MACRO_FACTOR);
       expect(await rewardPool.rsi()).to.be.equal(0);
@@ -90,7 +90,7 @@ export function RunAPRTests(): void {
     it("should set base", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
 
-      await rewardPool.connect(this.signers.system).setBase(1500);
+      await rewardPool.connect(this.signers.governance).setBase(1500);
 
       expect(await rewardPool.base()).to.be.equal(1500);
     });
@@ -109,7 +109,7 @@ export function RunAPRTests(): void {
     it("should set macro", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
 
-      await rewardPool.connect(this.signers.system).setMacro(10000);
+      await rewardPool.connect(this.signers.governance).setMacro(10000);
 
       expect(await rewardPool.macroFactor()).to.be.equal(10000);
     });
@@ -128,7 +128,7 @@ export function RunAPRTests(): void {
     it("should revert when trying to set higher rsi", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
 
-      await expect(rewardPool.connect(this.signers.system).setRSI(20000)).to.be.revertedWithCustomError(
+      await expect(rewardPool.connect(this.signers.governance).setRSI(20000)).to.be.revertedWithCustomError(
         rewardPool,
         "InvalidRSI"
       );
@@ -137,7 +137,7 @@ export function RunAPRTests(): void {
     it("should set rsi to zero, if the input is lower than the minimum", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
       const newRSI = MIN_RSI_BONUS.div(2); // ensure it will be lower than the min
-      await rewardPool.connect(this.signers.system).setRSI(newRSI);
+      await rewardPool.connect(this.signers.governance).setRSI(newRSI);
 
       expect(await rewardPool.rsi()).to.be.equal(0);
     });
@@ -145,7 +145,7 @@ export function RunAPRTests(): void {
     it("should set rsi", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
 
-      await rewardPool.connect(this.signers.system).setRSI(12000);
+      await rewardPool.connect(this.signers.governance).setRSI(12000);
 
       expect(await rewardPool.rsi()).to.be.equal(12000);
     });

--- a/test/RewardPool/APR.test.ts
+++ b/test/RewardPool/APR.test.ts
@@ -18,8 +18,10 @@ export function RunAPRTests(): void {
     it("should initialize correctly", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.initializedValidatorSetStateFixture);
       const managerRole = await rewardPool.MANAGER_ROLE();
+      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
 
       expect(await rewardPool.hasRole(managerRole, this.signers.governance.address)).to.be.true;
+      expect(await rewardPool.hasRole(adminRole, this.signers.governance.address)).to.be.true;
       expect(await rewardPool.base()).to.be.equal(INITIAL_BASE_APR);
       expect(await rewardPool.macroFactor()).to.be.equal(INITIAL_MACRO_FACTOR);
       expect(await rewardPool.rsi()).to.be.equal(0);

--- a/test/RewardPool/RewardPool.test.ts
+++ b/test/RewardPool/RewardPool.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import * as hre from "hardhat";
 import { expect } from "chai";
 
-import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK, ERRORS } from "../constants";
+import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
 import {
   calculateExpectedReward,
   commitEpoch,
@@ -16,42 +16,7 @@ import {
 } from "../helper";
 
 export function RunStakingClaimTests(): void {
-  describe("change minDelegate", function () {
-    it("should revert if non-default_admin_role address try to change MinDelegation", async function () {
-      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
-
-      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
-
-      await expect(
-        rewardPool.connect(this.signers.validators[0]).changeMinDelegation(this.minDelegation.mul(2))
-      ).to.be.revertedWith(ERRORS.accessControl(this.signers.validators[0].address.toLocaleLowerCase(), adminRole));
-
-      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
-    });
-
-    it("should revert if MinDelegation is too low", async function () {
-      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
-
-      const newLowMinDelegation = this.minStake.div(2);
-
-      await expect(rewardPool.connect(this.signers.system).changeMinDelegation(newLowMinDelegation))
-        .to.be.revertedWithCustomError(rewardPool, "InvalidMinDelegation")
-        .withArgs(newLowMinDelegation);
-
-      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
-    });
-
-    it("should change MinDelegation by default_admin_role address", async function () {
-      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
-
-      const newMinDelegation = this.minDelegation.mul(2);
-
-      await expect(rewardPool.connect(this.signers.system).changeMinDelegation(newMinDelegation)).to.not.be.reverted;
-
-      expect(await rewardPool.minDelegation()).to.be.equal(newMinDelegation);
-    });
-  });
-  describe("claim position reward", function () {
+  describe("Claim position reward", function () {
     it("should not be able to claim when active", async function () {
       const { stakerValidatorSet, systemValidatorSet, rewardPool } = await loadFixture(
         this.fixtures.newVestingValidatorFixture

--- a/test/RewardPool/RewardPool.test.ts
+++ b/test/RewardPool/RewardPool.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import * as hre from "hardhat";
 import { expect } from "chai";
 
-import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
+import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK, ERRORS } from "../constants";
 import {
   calculateExpectedReward,
   commitEpoch,
@@ -16,6 +16,41 @@ import {
 } from "../helper";
 
 export function RunStakingClaimTests(): void {
+  describe("change minDelegate", function () {
+    it("should revert if non-default_admin_role address try to change MinDelegation", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
+
+      await expect(
+        rewardPool.connect(this.signers.validators[0]).changeMinDelegation(this.minDelegation.mul(2))
+      ).to.be.revertedWith(ERRORS.accessControl(this.signers.validators[0].address.toLocaleLowerCase(), adminRole));
+
+      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
+    });
+
+    it("should revert if MinDelegation is too low", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const newLowMinDelegation = this.minStake.div(2);
+
+      await expect(rewardPool.connect(this.signers.system).changeMinDelegation(newLowMinDelegation))
+        .to.be.revertedWithCustomError(rewardPool, "InvalidMinDelegation")
+        .withArgs(newLowMinDelegation);
+
+      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
+    });
+
+    it("should change MinDelegation by default_admin_role address", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const newMinDelegation = this.minDelegation.mul(2);
+
+      await expect(rewardPool.connect(this.signers.system).changeMinDelegation(newMinDelegation)).to.not.be.reverted;
+
+      expect(await rewardPool.minDelegation()).to.be.equal(newMinDelegation);
+    });
+  });
   describe("claim position reward", function () {
     it("should not be able to claim when active", async function () {
       const { stakerValidatorSet, systemValidatorSet, rewardPool } = await loadFixture(

--- a/test/ValidatorSet/Delegation.test.ts
+++ b/test/ValidatorSet/Delegation.test.ts
@@ -5,7 +5,7 @@ import * as hre from "hardhat";
 
 // eslint-disable-next-line camelcase
 import { VestManager__factory } from "../../typechain-types";
-import { VESTING_DURATION_WEEKS, WEEK } from "../constants";
+import { ERRORS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
 import { calculatePenalty, claimPositionRewards, commitEpoch, commitEpochs, getUserManager } from "../helper";
 import {
   RunDelegateClaimTests,
@@ -14,6 +14,52 @@ import {
 } from "../RewardPool/RewardPool.test";
 
 export function RunDelegationTests(): void {
+  describe("Change minDelegate", function () {
+    it("should check that Governance has default_admin_role", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
+
+      expect(await rewardPool.hasRole(adminRole, this.signers.system.address)).to.be.false;
+      expect(await rewardPool.hasRole(adminRole, this.signers.admin.address)).to.be.false;
+      expect(await rewardPool.hasRole(adminRole, this.signers.governance.address)).to.be.true;
+    });
+    it("should revert if non-default_admin_role address try to change MinDelegation", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
+
+      await expect(
+        rewardPool.connect(this.signers.validators[0]).changeMinDelegation(this.minDelegation.mul(2))
+      ).to.be.revertedWith(ERRORS.accessControl(this.signers.validators[0].address.toLocaleLowerCase(), adminRole));
+
+      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
+    });
+
+    it("should revert if MinDelegation is too low", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const newLowMinDelegation = this.minStake.div(2);
+
+      await expect(rewardPool.connect(this.signers.governance).changeMinDelegation(newLowMinDelegation))
+        .to.be.revertedWithCustomError(rewardPool, "InvalidMinDelegation")
+        .withArgs(newLowMinDelegation);
+
+      expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
+    });
+
+    it("should change MinDelegation by default_admin_role address", async function () {
+      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
+
+      const newMinDelegation = this.minDelegation.mul(2);
+
+      await expect(rewardPool.connect(this.signers.governance).changeMinDelegation(newMinDelegation)).to.not.be
+        .reverted;
+
+      expect(await rewardPool.minDelegation()).to.be.equal(newMinDelegation);
+    });
+  });
+
   describe("Delegate", function () {
     it("should revert when delegating zero amount", async function () {
       const { validatorSet } = await loadFixture(this.fixtures.withdrawableFixture);

--- a/test/ValidatorSet/Delegation.test.ts
+++ b/test/ValidatorSet/Delegation.test.ts
@@ -15,15 +15,6 @@ import {
 
 export function RunDelegationTests(): void {
   describe("Change minDelegate", function () {
-    it("should check that Governance has default_admin_role", async function () {
-      const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
-
-      const adminRole = await rewardPool.DEFAULT_ADMIN_ROLE();
-
-      expect(await rewardPool.hasRole(adminRole, this.signers.system.address)).to.be.false;
-      expect(await rewardPool.hasRole(adminRole, this.signers.admin.address)).to.be.false;
-      expect(await rewardPool.hasRole(adminRole, this.signers.governance.address)).to.be.true;
-    });
     it("should revert if non-default_admin_role address try to change MinDelegation", async function () {
       const { rewardPool } = await loadFixture(this.fixtures.delegatedFixture);
 
@@ -41,9 +32,9 @@ export function RunDelegationTests(): void {
 
       const newLowMinDelegation = this.minStake.div(2);
 
-      await expect(rewardPool.connect(this.signers.governance).changeMinDelegation(newLowMinDelegation))
-        .to.be.revertedWithCustomError(rewardPool, "InvalidMinDelegation")
-        .withArgs(newLowMinDelegation);
+      await expect(
+        rewardPool.connect(this.signers.governance).changeMinDelegation(newLowMinDelegation)
+      ).to.be.revertedWithCustomError(rewardPool, "InvalidMinDelegation");
 
       expect(await rewardPool.minDelegation()).to.be.equal(this.minDelegation);
     });

--- a/test/ValidatorSet/Staking.test.ts
+++ b/test/ValidatorSet/Staking.test.ts
@@ -22,9 +22,9 @@ export function RunStakingTests(): void {
 
       const newMinStakeLow = this.minStake.div(2);
 
-      await expect(validatorSet.connect(this.signers.governance).changeMinStake(newMinStakeLow))
-        .to.be.revertedWithCustomError(validatorSet, "InvalidMinStake")
-        .withArgs(newMinStakeLow);
+      await expect(
+        validatorSet.connect(this.signers.governance).changeMinStake(newMinStakeLow)
+      ).to.be.revertedWithCustomError(validatorSet, "InvalidMinStake");
 
       expect(await validatorSet.minStake()).to.be.equal(this.minStake);
     });

--- a/test/ValidatorSet/Staking.test.ts
+++ b/test/ValidatorSet/Staking.test.ts
@@ -39,6 +39,7 @@ export function RunStakingTests(): void {
       expect(await validatorSet.minStake()).to.be.equal(newMinStake);
     });
   });
+
   describe("Stake", function () {
     it("should allow only registered validators to stake", async function () {
       // * Only the first three validators are being registered

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -83,7 +83,7 @@ async function initializedValidatorSetStateFixtureFunction(this: Mocha.Context) 
     validatorSet.address,
     this.signers.rewardWallet.address,
     this.minDelegation,
-    this.signers.system.address
+    this.signers.governance.address
   );
   await liquidToken.initialize("Liquidity Token", "LQT", this.signers.governance.address, systemValidatorSet.address);
   await systemValidatorSet.initialize(
@@ -192,7 +192,7 @@ async function stakedValidatorsStateFixtureFunction(this: Mocha.Context) {
   );
 
   // set the rsi to the minimum value
-  await rewardPool.connect(this.signers.system).setRSI(MIN_RSI_BONUS);
+  await rewardPool.connect(this.signers.governance).setRSI(MIN_RSI_BONUS);
   await validatorSet.connect(this.signers.validators[0]).stake({ value: this.minStake.mul(2) });
   await validatorSet.connect(this.signers.validators[1]).stake({ value: this.minStake.mul(2) });
 


### PR DESCRIPTION
1. Add an external function in RewardPool changeMinDelegation, that is callable only by the default_admin_role (governance)
2. A private function that handles the logic for changing minDelegation and is used on initializing
3. Add new custom error - InvalidMinDelegation
4. Add an external function in RewardPool changeMinStake, that is callable only by the owner (governance)
5. A private function that handles the logic for changing minStake and is used on initializing
6. Apply needed updates on Interfaces 
7. Add tests to see if functions work
8. Fix RewardPool initializing with system address, not governance on tests. Apply needed changes so it all works well.