### PR TITLE
new ban mechanism based on validator participation

### DIFF
--- a/contracts/RewardPool/RewardPool.sol
+++ b/contracts/RewardPool/RewardPool.sol
@@ -79,18 +79,16 @@ contract RewardPool is RewardPoolBase, System, StakingRewards, DelegationRewards
     ) private returns (uint256 reward) {
         require(uptime.signedBlocks <= totalBlocks, "SIGNED_BLOCKS_EXCEEDS_TOTAL");
 
-        (, , uint256 totalStake, uint256 commission, , bool active) = validatorSet.getValidator(uptime.validator);
-        if (!active) {
-            return 0;
-        }
+        (, , uint256 totalStake, uint256 commission, , ) = validatorSet.getValidator(uptime.validator);
 
         DelegationPool storage delegationPool = delegationPools[uptime.validator];
+        uint256 delegation = delegationPool.supply;
         // slither-disable-next-line divide-before-multiply
-        uint256 validatorReward = (fullReward * (totalStake + delegationPool.supply) * uptime.signedBlocks) /
+        uint256 validatorReward = (fullReward * (totalStake + delegation) * uptime.signedBlocks) /
             (totalSupply * totalBlocks);
         (uint256 validatorShares, uint256 delegatorShares) = _calculateValidatorAndDelegatorShares(
             totalStake,
-            delegationPool.supply,
+            delegation,
             validatorReward,
             commission
         );

--- a/contracts/RewardPool/RewardPoolBase.sol
+++ b/contracts/RewardPool/RewardPoolBase.sol
@@ -14,6 +14,13 @@ abstract contract RewardPoolBase is IRewardPool, Initializable {
     /// @notice The address of the ValidatorSet contract
     IValidatorSet public validatorSet;
 
+    // _______________ Modifiers _______________
+
+    modifier onlyValidatorSet() {
+        if (msg.sender != address(validatorSet)) revert Unauthorized("VALIDATORSET");
+        _;
+    }
+
     // _______________ Initializer _______________
 
     function __RewardPoolBase_init(IValidatorSet newValidatorSet) internal onlyInitializing {
@@ -22,10 +29,5 @@ abstract contract RewardPoolBase is IRewardPool, Initializable {
 
     function __RewardPoolBase_init_unchained(IValidatorSet newValidatorSet) internal onlyInitializing {
         validatorSet = newValidatorSet;
-    }
-
-    modifier onlyValidatorSet() {
-        if (msg.sender != address(validatorSet)) revert Unauthorized("VALIDATORSET");
-        _;
     }
 }

--- a/contracts/ValidatorSet/IValidatorSet.sol
+++ b/contracts/ValidatorSet/IValidatorSet.sol
@@ -96,7 +96,7 @@ interface IValidatorSet {
     function getValidators() external view returns (address[] memory);
 
     /**
-     * @notice A function to update when the validator was lastly active
+     * @notice Method to update when the validator was lastly active which can be executed only by the RewardPool
      * @param validator The validator to set the last participation for
      */
     function updateValidatorParticipation(address validator) external;

--- a/contracts/ValidatorSet/IValidatorSet.sol
+++ b/contracts/ValidatorSet/IValidatorSet.sol
@@ -24,6 +24,7 @@ enum ValidatorStatus {
     None,
     Whitelisted,
     Registered,
+    Active,
     Banned
 }
 
@@ -93,4 +94,10 @@ interface IValidatorSet {
      * @return Returns array of addresses
      */
     function getValidators() external view returns (address[] memory);
+
+    /**
+     * @notice A function to update when the validator was lastly active
+     * @param validator The validator to set the last participation for
+     */
+    function updateValidatorParticipation(address validator) external;
 }

--- a/contracts/ValidatorSet/ValidatorSet.sol
+++ b/contracts/ValidatorSet/ValidatorSet.sol
@@ -18,18 +18,6 @@ import "./../common/libs/SafeMathInt.sol";
 contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent, Staking, Delegation, Inspector {
     using ArraysUpgradeable for uint256[];
 
-    /// @notice Epoch data linked with the epoch id
-    mapping(uint256 => Epoch) public epochs;
-    /// @notice Array with epoch ending blocks
-    uint256[] public epochEndBlocks;
-
-    // _______________ Modifiers _______________
-
-    modifier onlyRewardPool() {
-        if (msg.sender != address(rewardPool)) revert Unauthorized("REWARD_POOL");
-        _;
-    }
-
     // _______________ Initializer _______________
 
     /**
@@ -91,8 +79,7 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
     }
 
     /**
-     * @notice Get the validator by its address
-     * @param validatorAddress address
+     * @inheritdoc IValidatorSet
      */
     function getValidator(
         address validatorAddress
@@ -114,14 +101,7 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
         stake = totalStake - rewardPool.totalDelegationOf(validatorAddress);
         commission = v.commission;
         withdrawableRewards = rewardPool.getValidatorReward(validatorAddress);
-        active = v.status == ValidatorStatus.Registered;
-    }
-
-    /**
-     * @inheritdoc IValidatorSet
-     */
-    function getValidators() public view returns (address[] memory) {
-        return validatorsAddresses;
+        active = v.status == ValidatorStatus.Active;
     }
 
     /**
@@ -138,6 +118,15 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
     function getEpochByBlock(uint256 blockNumber) external view returns (Epoch memory) {
         uint256 epochIndex = epochEndBlocks.findUpperBound(blockNumber);
         return epochs[epochIndex];
+    }
+
+    // _______________ Public functions _______________
+
+    /**
+     * @inheritdoc IValidatorSet
+     */
+    function getValidators() public view returns (address[] memory) {
+        return validatorsAddresses;
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/ValidatorSet/ValidatorSet.sol
+++ b/contracts/ValidatorSet/ValidatorSet.sol
@@ -120,6 +120,13 @@ contract ValidatorSet is ValidatorSetBase, System, AccessControl, PowerExponent,
         return epochs[epochIndex];
     }
 
+    /**
+     * @inheritdoc IValidatorSet
+     */
+    function updateValidatorParticipation(address validator) external onlyRewardPool {
+        _updateParticipation(validator);
+    }
+
     // _______________ Public functions _______________
 
     /**

--- a/contracts/ValidatorSet/ValidatorSet.sol
+++ b/contracts/ValidatorSet/ValidatorSet.sol
@@ -10,7 +10,6 @@ import "./modules/Staking/Staking.sol";
 import "./modules/Delegation/Delegation.sol";
 import "./modules/Inspector/Inspector.sol";
 import "./../common/System/System.sol";
-
 import "./../common/libs/SafeMathInt.sol";
 
 // TODO: setup use of reward account that would handle the amounts of rewards

--- a/contracts/ValidatorSet/ValidatorSetBase.sol
+++ b/contracts/ValidatorSet/ValidatorSetBase.sol
@@ -33,7 +33,7 @@ abstract contract ValidatorSetBase is IValidatorSet, Initializable {
      * @notice Mapping that keeps the last time when a validator has participated in the consensus
      * @dev Keep in mind that the validator will initially be set active when stake,
      * but it will be able to participate in the next epoch. So, the validator will have
-     * less blocks to be considered for ban.
+     * less blocks to participate before getting eligible for ban.
      */
     mapping(address => uint256) public validatorParticipation;
 
@@ -94,6 +94,15 @@ abstract contract ValidatorSetBase is IValidatorSet, Initializable {
      */
     function _updateParticipation(address validator) internal {
         validatorParticipation[validator] = block.number;
+    }
+
+    /**
+     * @notice Method used to burn funds
+     * @param amount The amount to be burned
+     */
+    function _burnAmount(uint256 amount) internal {
+        (bool success, ) = address(0).call{value: amount}("");
+        require(success, "Failed to burn amount");
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/ValidatorSet/modules/Delegation/Delegation.sol
+++ b/contracts/ValidatorSet/modules/Delegation/Delegation.sol
@@ -81,9 +81,7 @@ abstract contract Delegation is
 
     // _______________ Private functions _______________
 
-    function _delegate(address validator, address delegator, uint256 amount) private {
-        if (validators[validator].status != ValidatorStatus.Registered) revert Unauthorized("INVALID_VALIDATOR");
-
+    function _delegate(address validator, address delegator, uint256 amount) private onlyActiveValidator(validator) {
         _mint(validator, amount); // increase validator power
         StateSyncer._syncStake(validator, balanceOf(validator));
         LiquidStaking._distributeTokens(delegator, amount);

--- a/contracts/ValidatorSet/modules/Delegation/Delegation.sol
+++ b/contracts/ValidatorSet/modules/Delegation/Delegation.sol
@@ -82,7 +82,7 @@ abstract contract Delegation is
     // _______________ Private functions _______________
 
     function _delegate(address validator, address delegator, uint256 amount) private onlyActiveValidator(validator) {
-        _mint(validator, amount); // increase validator power
+        _increaseAccountBalance(validator, amount); // increase validator power
         StateSyncer._syncStake(validator, balanceOf(validator));
         LiquidStaking._distributeTokens(delegator, amount);
 
@@ -90,15 +90,10 @@ abstract contract Delegation is
     }
 
     function _undelegate(address validator, address delegator, uint256 amount) private {
-        _burn(validator, amount); // decrease validator power
+        _decreaseAccountBalance(validator, amount); // decrease validator power
         StateSyncer._syncStake(validator, balanceOf(validator));
         LiquidStaking._collectDelegatorTokens(delegator, amount);
 
         emit Undelegated(validator, delegator, amount);
-    }
-
-    function _burnAmount(uint256 amount) private {
-        (bool success, ) = address(0).call{value: amount}("");
-        require(success, "Failed to burn amount");
     }
 }

--- a/contracts/ValidatorSet/modules/Delegation/VestedDelegation.sol
+++ b/contracts/ValidatorSet/modules/Delegation/VestedDelegation.sol
@@ -18,7 +18,6 @@ abstract contract VestedDelegation is IVestedDelegation, VestFactory {
         if (!isVestingManager(msg.sender)) {
             revert NotVestingManager();
         }
-
         _;
     }
 

--- a/contracts/ValidatorSet/modules/Inspector/IInspector.sol
+++ b/contracts/ValidatorSet/modules/Inspector/IInspector.sol
@@ -17,12 +17,6 @@ interface IInspector {
     error ThresholdNotReached();
 
     /**
-     * @notice Manually ban a validator by the owner
-     * @param validator Address of the validator
-     */
-    function banValidatorByOwner(address validator) external;
-
-    /**
      * @notice Set the penalty amount for the banned validators
      * @param newPenalty Amount of the penalty
      */
@@ -47,8 +41,8 @@ interface IInspector {
     function withdrawBannedFunds() external;
 
     /**
-     * @notice Public method where anyone can execute to ban a validator
-     * @dev This function will ban only if the input validator has reached the ban treshold
+     * @notice Method used to ban a validator, if the ban threshold is reached
+     * @dev This function will validate the threshold only if the executor is not the governor, otherwise will forcely ban the validator
      * @param validator Address of the validator
      */
     function banValidator(address validator) external;

--- a/contracts/ValidatorSet/modules/Inspector/IInspector.sol
+++ b/contracts/ValidatorSet/modules/Inspector/IInspector.sol
@@ -14,12 +14,13 @@ struct WithdrawalInfo {
 interface IInspector {
     event ValidatorBanned(address indexed validator);
 
+    error ThresholdNotReached();
+
     /**
-     * @notice Manual ban of a validator
-     * @dev Function can be executed only by the governor/owner
+     * @notice Manually ban a validator by the owner
      * @param validator Address of the validator
      */
-    function banValidator(address validator) external;
+    function banValidatorByOwner(address validator) external;
 
     /**
      * @notice Set the penalty amount for the banned validators
@@ -34,8 +35,21 @@ interface IInspector {
     function setReporterReward(uint256 newReward) external;
 
     /**
+     * @notice Set the threshold that needs to be reached to ban a validator
+     * @param newThreshold The new threshold in blocks
+     */
+    function setBanThreshold(uint256 newThreshold) external;
+
+    /**
      * @notice Withdraw funds left for a banned validator
      * @dev Function can be executed only by the banned validator
      */
     function withdrawBannedFunds() external;
+
+    /**
+     * @notice Public method where anyone can execute to ban a validator
+     * @dev This function will ban only if the input validator has reached the ban treshold
+     * @param validator Address of the validator
+     */
+    function banValidator(address validator) external;
 }

--- a/contracts/ValidatorSet/modules/Inspector/Inspector.sol
+++ b/contracts/ValidatorSet/modules/Inspector/Inspector.sol
@@ -106,7 +106,7 @@ abstract contract Inspector is IInspector, Staking {
         _ban(validator);
     }
 
-    // _______________ Public functions _______________
+    // _______________ Private functions _______________
 
     function _ban(address validator) private {
         uint256 totalAmount = balanceOf(validator);

--- a/contracts/ValidatorSet/modules/Inspector/Inspector.sol
+++ b/contracts/ValidatorSet/modules/Inspector/Inspector.sol
@@ -12,6 +12,9 @@ abstract contract Inspector is IInspector, Staking {
     /// @notice The reward for the person who reports a validator that have to be banned
     uint256 public reporterReward;
 
+    /// @notice The block numbers threshold that needs to be passed to ban a validator
+    uint256 public banTreshold;
+
     /**
      * @notice The withdrawal info that is required for a banned validator to withdraw the funds left
      * @dev The withdrawal amount is calculated as the difference between
@@ -23,7 +26,7 @@ abstract contract Inspector is IInspector, Staking {
 
     // Only address that is banned
     modifier onlyBanned() {
-        if (validators[msg.sender].status != ValidatorStatus.Banned) revert Unauthorized("BANNED_VALIDATOR");
+        if (validators[msg.sender].status != ValidatorStatus.Banned) revert Unauthorized("UNBANNED_VALIDATOR");
         _;
     }
 
@@ -36,6 +39,7 @@ abstract contract Inspector is IInspector, Staking {
     function __Inspector_init_unchained() internal onlyInitializing {
         validatorPenalty = 700 ether;
         reporterReward = 300 ether;
+        banTreshold = 123428; // the approximate number of blocks for 72 hours
     }
 
     // _______________ External functions _______________
@@ -43,25 +47,8 @@ abstract contract Inspector is IInspector, Staking {
     /**
      * @inheritdoc IInspector
      */
-    function banValidator(address validator) external onlyOwner {
-        if (validators[validator].status != ValidatorStatus.Registered) revert Unauthorized("UNREGISTERED_VALIDATOR");
-
-        uint256 stakedAmount = balanceOf(validator);
-        if (stakedAmount != 0) {
-            _burn(validator, stakedAmount);
-            StateSyncer._syncStake(validator, 0);
-            uint256 amountLeft = rewardPool.onUnstake(validator, stakedAmount, 0);
-
-            uint256 penalty = validatorPenalty;
-            if (amountLeft < penalty) penalty = amountLeft;
-
-            withdrawalBalances[validator].liquidTokens = stakedAmount;
-            withdrawalBalances[validator].withdrawableAmount = amountLeft - penalty;
-        }
-
-        validators[validator].status = ValidatorStatus.Banned;
-
-        emit ValidatorBanned(validator);
+    function banValidatorByOwner(address validator) external onlyOwner {
+        _ban(validator);
     }
 
     // _______________ Public functions _______________
@@ -83,6 +70,13 @@ abstract contract Inspector is IInspector, Staking {
     /**
      * @inheritdoc IInspector
      */
+    function setBanThreshold(uint256 newThreshold) public onlyOwner {
+        banTreshold = newThreshold;
+    }
+
+    /**
+     * @inheritdoc IInspector
+     */
     function withdrawBannedFunds() public onlyBanned {
         WithdrawalInfo memory withdrawalBalance = withdrawalBalances[msg.sender];
 
@@ -91,6 +85,47 @@ abstract contract Inspector is IInspector, Staking {
         LiquidStaking._collectTokens(msg.sender, withdrawalBalance.liquidTokens);
 
         _withdraw(msg.sender, withdrawalBalance.withdrawableAmount);
+    }
+
+    /**
+     * @inheritdoc IInspector
+     */
+    function banValidator(address validator) public {
+        uint256 lastCommittedEndBlock = epochs[currentEpochId - 1].endBlock;
+        // number of blocks that the validator has been active for, must be more than threshold
+        uint256 activeFor = lastCommittedEndBlock - validatorParticipation[validator].activeFrom;
+        // if the validator has not been active for more than the threshold or has been active in the required timeframe, then exit
+        if (
+            validatorParticipation[validator].activeFrom == 0 ||
+            activeFor < banTreshold ||
+            lastCommittedEndBlock - validatorParticipation[validator].lastlyActive < banTreshold
+        ) {
+            revert ThresholdNotReached();
+        }
+
+        _ban(validator);
+    }
+
+    // _______________ Public functions _______________
+
+    function _ban(address validator) private {
+        uint256 totalAmount = balanceOf(validator);
+        uint256 validatorStake = totalAmount - rewardPool.totalDelegationOf(validator);
+        if (validatorStake != 0) {
+            _burn(validator, validatorStake);
+            StateSyncer._syncStake(validator, 0);
+            uint256 amountLeft = rewardPool.onUnstake(validator, validatorStake, 0);
+
+            uint256 penalty = validatorPenalty;
+            if (amountLeft < penalty) penalty = amountLeft;
+
+            withdrawalBalances[validator].liquidTokens = validatorStake;
+            withdrawalBalances[validator].withdrawableAmount = amountLeft - penalty;
+        }
+
+        validators[validator].status = ValidatorStatus.Banned;
+
+        emit ValidatorBanned(validator);
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/ValidatorSet/modules/Inspector/Inspector.sol
+++ b/contracts/ValidatorSet/modules/Inspector/Inspector.sol
@@ -12,7 +12,7 @@ abstract contract Inspector is IInspector, Staking {
     /// @notice The reward for the person who reports a validator that have to be banned
     uint256 public reporterReward;
 
-    /// @notice The block numbers threshold that needs to be passed to ban a validator
+    /// @notice Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator
     uint256 public banTreshold;
 
     /**
@@ -40,15 +40,6 @@ abstract contract Inspector is IInspector, Staking {
         validatorPenalty = 700 ether;
         reporterReward = 300 ether;
         banTreshold = 123428; // the approximate number of blocks for 72 hours
-    }
-
-    // _______________ External functions _______________
-
-    /**
-     * @inheritdoc IInspector
-     */
-    function banValidatorByOwner(address validator) external onlyOwner {
-        _ban(validator);
     }
 
     // _______________ Public functions _______________
@@ -90,16 +81,10 @@ abstract contract Inspector is IInspector, Staking {
     /**
      * @inheritdoc IInspector
      */
-    function banValidator(address validator) public {
+    function banValidator(address validator) public onlyValidator(validator) {
         uint256 lastCommittedEndBlock = epochs[currentEpochId - 1].endBlock;
-        // number of blocks that the validator has been active for, must be more than threshold
-        uint256 activeFor = lastCommittedEndBlock - validatorParticipation[validator].activeFrom;
-        // if the validator has not been active for more than the threshold or has been active in the required timeframe, then exit
-        if (
-            validatorParticipation[validator].activeFrom == 0 ||
-            activeFor < banTreshold ||
-            lastCommittedEndBlock - validatorParticipation[validator].lastlyActive < banTreshold
-        ) {
+        // check if the threshold is reached when the method is not executed by the owner (governance)
+        if (msg.sender != owner() && lastCommittedEndBlock - validatorParticipation[validator] < banTreshold) {
             revert ThresholdNotReached();
         }
 
@@ -108,24 +93,65 @@ abstract contract Inspector is IInspector, Staking {
 
     // _______________ Private functions _______________
 
+    /**
+     * @dev A method that executes the actions for the actual ban
+     * @param validator The address of the validator
+     */
     function _ban(address validator) private {
         uint256 totalAmount = balanceOf(validator);
         uint256 validatorStake = totalAmount - rewardPool.totalDelegationOf(validator);
+        uint256 reward = 0;
         if (validatorStake != 0) {
-            _burn(validator, validatorStake);
-            StateSyncer._syncStake(validator, 0);
-            uint256 amountLeft = rewardPool.onUnstake(validator, validatorStake, 0);
+            _burnAccountStake(validator, validatorStake);
 
-            uint256 penalty = validatorPenalty;
-            if (amountLeft < penalty) penalty = amountLeft;
+            (uint256 amountLeftToWithdraw, uint256 rewardToWithdraw) = _calculateWithdrawals(validator, validatorStake);
 
+            reward = rewardToWithdraw;
             withdrawalBalances[validator].liquidTokens = validatorStake;
-            withdrawalBalances[validator].withdrawableAmount = amountLeft - penalty;
+            withdrawalBalances[validator].withdrawableAmount = amountLeftToWithdraw;
         }
 
         validators[validator].status = ValidatorStatus.Banned;
+        if (reward != 0) _withdraw(msg.sender, reward);
 
         emit ValidatorBanned(validator);
+    }
+
+    function _burnAccountStake(address account, uint256 stake) private {
+        _burn(account, stake);
+        StateSyncer._syncStake(account, 0);
+    }
+
+    /**
+     * @dev This function is used to calculation amount that will be left to withdraw
+     * after applying validator penalty and the reward for the reporter
+     * @param validator The address of the validator
+     * @param validatorStake The stake of the validator
+     * @return amountLeftToWithdraw The amount that will be left to withdraw by the autor
+     * @return rewardToWithdraw The reward that will be send to the reporter
+     */
+    function _calculateWithdrawals(
+        address validator,
+        uint256 validatorStake
+    ) private returns (uint256 amountLeftToWithdraw, uint256 rewardToWithdraw) {
+        amountLeftToWithdraw = rewardPool.onUnstake(validator, validatorStake, 0);
+        if (msg.sender != owner()) {
+            uint256 _reporterReward = reporterReward;
+            if (amountLeftToWithdraw < _reporterReward) {
+                rewardToWithdraw = amountLeftToWithdraw;
+                amountLeftToWithdraw = 0;
+            } else {
+                rewardToWithdraw = _reporterReward;
+                amountLeftToWithdraw -= rewardToWithdraw;
+            }
+        }
+
+        uint256 penalty = validatorPenalty;
+        if (amountLeftToWithdraw < penalty) {
+            amountLeftToWithdraw = 0;
+        } else if (amountLeftToWithdraw != 0) {
+            amountLeftToWithdraw -= penalty;
+        }
     }
 
     // slither-disable-next-line unused-state,naming-convention

--- a/contracts/ValidatorSet/modules/Staking/BalanceState.sol
+++ b/contracts/ValidatorSet/modules/Staking/BalanceState.sol
@@ -23,7 +23,7 @@ abstract contract BalanceState is IValidatorSet {
     /**
      * @dev Creates a `value` amount of tokens and assigns them to `account`.
      */
-    function _mint(address account, uint256 value) internal {
+    function _increaseAccountBalance(address account, uint256 value) internal {
         require(account != address(0), "ZERO_ADDRESS");
 
         stakeBalances[account] += value;
@@ -31,9 +31,9 @@ abstract contract BalanceState is IValidatorSet {
     }
 
     /**
-     * @dev Destroys a `value` amount of tokens from `account`, lowering the balance.
+     * @dev Destroys a `value` amount of tokens from `account`, decreasing the balance.
      */
-    function _burn(address account, uint256 value) internal {
+    function _decreaseAccountBalance(address account, uint256 value) internal {
         require(account != address(0), "ZERO_ADDRESS");
         require(stakeBalances[account] - value >= 0, "LOW_BALANCE");
 

--- a/contracts/ValidatorSet/modules/Staking/IStaking.sol
+++ b/contracts/ValidatorSet/modules/Staking/IStaking.sol
@@ -1,16 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-/**
- * @notice Structure for the participation of the validators
- * @dev activeFrom is the block number when the validator become active.
- * The lastlyActive is the block when the validator has been active lastly, updates each participation epoch
- */
-struct Participation {
-    uint256 activeFrom;
-    uint256 lastlyActive;
-}
-
 interface IStaking {
     event NewValidator(address indexed validator, uint256[4] blsKey);
     event CommissionUpdated(address indexed validator, uint256 newCommission);

--- a/contracts/ValidatorSet/modules/Staking/IStaking.sol
+++ b/contracts/ValidatorSet/modules/Staking/IStaking.sol
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+/**
+ * @notice Structure for the participation of the validators
+ * @dev activeFrom is the block number when the validator become active.
+ * The lastlyActive is the block when the validator has been active lastly, updates each participation epoch
+ */
+struct Participation {
+    uint256 activeFrom;
+    uint256 lastlyActive;
+}
+
 interface IStaking {
     event NewValidator(address indexed validator, uint256[4] blsKey);
     event CommissionUpdated(address indexed validator, uint256 newCommission);

--- a/contracts/ValidatorSet/modules/Staking/Staking.sol
+++ b/contracts/ValidatorSet/modules/Staking/Staking.sol
@@ -111,13 +111,12 @@ abstract contract Staking is IStaking, ValidatorSetBase, BalanceState, Withdrawa
         uint256 currentBalance = balanceOf(account);
         if (amount + currentBalance < minStake) revert StakeRequirement({src: "stake", msg: "STAKE_TOO_LOW"});
 
-        _mint(account, amount);
+        _increaseAccountBalance(account, amount);
         StateSyncer._syncStake(account, currentBalance + amount);
         LiquidStaking._distributeTokens(account, amount);
 
         if (currentBalance == 0) {
             validators[account].status = ValidatorStatus.Active;
-            // validatorParticipation[account] = block.number;
             _updateParticipation(account);
         }
 
@@ -131,16 +130,14 @@ abstract contract Staking is IStaking, ValidatorSetBase, BalanceState, Withdrawa
         uint256 totalStake = balanceOf(validator);
         uint256 delegation = rewardPool.totalDelegationOf(validator);
         uint256 validatorStake = totalStake - delegation;
-        // if (amount > totalStake || amount + delegation > totalStake)
         if (amount > validatorStake) revert StakeRequirement({src: "unstake", msg: "INSUFFICIENT_BALANCE"});
 
-        // uint256 validatorStake = totalStake - delegation;
         totalStakeLeft = totalStake - amount;
         validatorStakeLeft = validatorStake - amount;
         if (validatorStakeLeft < minStake && validatorStakeLeft != 0)
             revert StakeRequirement({src: "unstake", msg: "STAKE_TOO_LOW"});
 
-        _burn(validator, amount);
+        _decreaseAccountBalance(validator, amount);
     }
 
     // _______________ Private functions _______________

--- a/docs/ValidatorSet/IValidatorSet.md
+++ b/docs/ValidatorSet/IValidatorSet.md
@@ -137,6 +137,22 @@ Returns the total supply
 |---|---|---|
 | _0 | uint256 | Total supply |
 
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
+
 
 
 ## Events

--- a/docs/ValidatorSet/IValidatorSet.md
+++ b/docs/ValidatorSet/IValidatorSet.md
@@ -143,7 +143,7 @@ Returns the total supply
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -229,10 +229,10 @@ Returns the total balance of a given validator
 |---|---|---|
 | _0 | uint256 | Validator&#39;s balance |
 
-### banTreshold
+### banThreshold
 
 ```solidity
-function banTreshold() external view returns (uint256)
+function banThreshold() external view returns (uint256)
 ```
 
 Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -229,15 +229,48 @@ Returns the total balance of a given validator
 |---|---|---|
 | _0 | uint256 | Validator&#39;s balance |
 
+### banTreshold
+
+```solidity
+function banTreshold() external view returns (uint256)
+```
+
+The block numbers threshold that needs to be passed to ban a validator
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### banValidator
 
 ```solidity
 function banValidator(address validator) external nonpayable
 ```
 
-Manual ban of a validator
+Public method where anyone can execute to ban a validator
 
-*Function can be executed only by the governor/owner*
+*This function will ban only if the input validator has reached the ban treshold*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+### banValidatorByOwner
+
+```solidity
+function banValidatorByOwner(address validator) external nonpayable
+```
+
+Manually ban a validator by the owner
+
+
 
 #### Parameters
 
@@ -476,7 +509,7 @@ Gets the vesting managers per user address for fast off-chain lookup.
 function getValidator(address validatorAddress) external view returns (uint256[4] blsKey, uint256 stake, uint256 totalStake, uint256 commission, uint256 withdrawableRewards, bool active)
 ```
 
-Get the validator by its address
+Gets validator by address.
 
 
 
@@ -484,18 +517,18 @@ Get the validator by its address
 
 | Name | Type | Description |
 |---|---|---|
-| validatorAddress | address | address |
+| validatorAddress | address | undefined |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| blsKey | uint256[4] | undefined |
-| stake | uint256 | undefined |
-| totalStake | uint256 | undefined |
-| commission | uint256 | undefined |
-| withdrawableRewards | uint256 | undefined |
-| active | bool | undefined |
+| blsKey | uint256[4] | BLS public key |
+| stake | uint256 | self-stake |
+| totalStake | uint256 | self-stake + delegation |
+| commission | uint256 | commission |
+| withdrawableRewards | uint256 | withdrawable rewards |
+| active | bool | activity status |
 
 ### getValidators
 
@@ -778,6 +811,22 @@ function rewardPool() external view returns (contract IRewardPool)
 |---|---|---|
 | _0 | contract IRewardPool | undefined |
 
+### setBanThreshold
+
+```solidity
+function setBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to ban a validator
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
 ### setCommission
 
 ```solidity
@@ -1029,6 +1078,22 @@ Set new pending exponent, to be activated in the next commit epoch
 |---|---|---|
 | newValue | uint256 | New Voting Power Exponent Numerator |
 
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
+
 ### userVestManagers
 
 ```solidity
@@ -1051,6 +1116,29 @@ Additional mapping to store all vesting managers per user address for fast off-c
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+```
+
+A collection of the validators&#39; participation
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| activeFrom | uint256 | undefined |
+| lastlyActive | uint256 | undefined |
 
 ### validatorPenalty
 
@@ -1704,6 +1792,17 @@ error StakeRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
+
+### ThresholdNotReached
+
+```solidity
+error ThresholdNotReached()
+```
+
+
+
+
+
 
 ### Unauthorized
 

--- a/docs/ValidatorSet/ValidatorSet.md
+++ b/docs/ValidatorSet/ValidatorSet.md
@@ -235,7 +235,7 @@ Returns the total balance of a given validator
 function banTreshold() external view returns (uint256)
 ```
 
-The block numbers threshold that needs to be passed to ban a validator
+Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator
 
 
 
@@ -252,25 +252,9 @@ The block numbers threshold that needs to be passed to ban a validator
 function banValidator(address validator) external nonpayable
 ```
 
-Public method where anyone can execute to ban a validator
+Method used to ban a validator, if the ban threshold is reached
 
-*This function will ban only if the input validator has reached the ban treshold*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| validator | address | Address of the validator |
-
-### banValidatorByOwner
-
-```solidity
-function banValidatorByOwner(address validator) external nonpayable
-```
-
-Manually ban a validator by the owner
-
-
+*This function will validate the threshold only if the executor is not the governor, otherwise will forcely ban the validator*
 
 #### Parameters
 
@@ -1084,7 +1068,7 @@ Set new pending exponent, to be activated in the next commit epoch
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -1120,10 +1104,10 @@ Additional mapping to store all vesting managers per user address for fast off-c
 ### validatorParticipation
 
 ```solidity
-function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+function validatorParticipation(address) external view returns (uint256)
 ```
 
-A collection of the validators&#39; participation
+Mapping that keeps the last time when a validator has participated in the consensus
 
 
 
@@ -1137,8 +1121,7 @@ A collection of the validators&#39; participation
 
 | Name | Type | Description |
 |---|---|---|
-| activeFrom | uint256 | undefined |
-| lastlyActive | uint256 | undefined |
+| _0 | uint256 | undefined |
 
 ### validatorPenalty
 

--- a/docs/ValidatorSet/ValidatorSetBase.md
+++ b/docs/ValidatorSet/ValidatorSetBase.md
@@ -83,6 +83,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -204,6 +250,22 @@ Returns the total supply
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | Total supply |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### validators
 

--- a/docs/ValidatorSet/ValidatorSetBase.md
+++ b/docs/ValidatorSet/ValidatorSetBase.md
@@ -275,7 +275,7 @@ function validatorParticipation(address) external view returns (uint256)
 
 Mapping that keeps the last time when a validator has participated in the consensus
 
-*Keep in mind that the validator will initially be set active when stake, but it will be able to participate in the next epoch. So, the validator will have less blocks to be considered for ban.*
+*Keep in mind that the validator will initially be set active when stake, but it will be able to participate in the next epoch. So, the validator will have less blocks to participate before getting eligible for ban.*
 
 #### Parameters
 

--- a/docs/ValidatorSet/ValidatorSetBase.md
+++ b/docs/ValidatorSet/ValidatorSetBase.md
@@ -257,7 +257,7 @@ Returns the total supply
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -266,6 +266,28 @@ A function to update when the validator was lastly active
 | Name | Type | Description |
 |---|---|---|
 | validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+*Keep in mind that the validator will initially be set active when stake, but it will be able to participate in the next epoch. So, the validator will have less blocks to be considered for ban.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/AccessControl/AccessControl.md
+++ b/docs/ValidatorSet/modules/AccessControl/AccessControl.md
@@ -110,6 +110,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -308,6 +354,22 @@ function transferOwnership(address newOwner) external nonpayable
 | Name | Type | Description |
 |---|---|---|
 | newOwner | address | undefined |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/AccessControl/AccessControl.md
+++ b/docs/ValidatorSet/modules/AccessControl/AccessControl.md
@@ -361,7 +361,7 @@ function transferOwnership(address newOwner) external nonpayable
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -370,6 +370,28 @@ A function to update when the validator was lastly active
 | Name | Type | Description |
 |---|---|---|
 | validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Delegation/Delegation.md
+++ b/docs/ValidatorSet/modules/Delegation/Delegation.md
@@ -632,7 +632,7 @@ Undelegates amount from validator for vesting position. Apply penalty in case ve
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -664,6 +664,28 @@ Additional mapping to store all vesting managers per user address for fast off-c
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Delegation/Delegation.md
+++ b/docs/ValidatorSet/modules/Delegation/Delegation.md
@@ -176,6 +176,52 @@ Delegates sent amount to validator. Set vesting position data. Delete old top-up
 | validator | address | Validator to delegate to |
 | durationWeeks | uint256 | Duration of the vesting in weeks |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -579,6 +625,22 @@ Undelegates amount from validator for vesting position. Apply penalty in case ve
 |---|---|---|
 | validator | address | Validator to undelegate from |
 | amount | uint256 | Amount to be undelegated |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### userVestManagers
 

--- a/docs/ValidatorSet/modules/Inspector/IInspector.md
+++ b/docs/ValidatorSet/modules/Inspector/IInspector.md
@@ -16,15 +16,47 @@
 function banValidator(address validator) external nonpayable
 ```
 
-Manual ban of a validator
+Public method where anyone can execute to ban a validator
 
-*Function can be executed only by the governor/owner*
+*This function will ban only if the input validator has reached the ban treshold*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | validator | address | Address of the validator |
+
+### banValidatorByOwner
+
+```solidity
+function banValidatorByOwner(address validator) external nonpayable
+```
+
+Manually ban a validator by the owner
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+### setBanThreshold
+
+```solidity
+function setBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to ban a validator
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
 
 ### setReporterReward
 
@@ -88,6 +120,20 @@ event ValidatorBanned(address indexed validator)
 | Name | Type | Description |
 |---|---|---|
 | validator `indexed` | address | undefined |
+
+
+
+## Errors
+
+### ThresholdNotReached
+
+```solidity
+error ThresholdNotReached()
+```
+
+
+
+
 
 
 

--- a/docs/ValidatorSet/modules/Inspector/IInspector.md
+++ b/docs/ValidatorSet/modules/Inspector/IInspector.md
@@ -16,25 +16,9 @@
 function banValidator(address validator) external nonpayable
 ```
 
-Public method where anyone can execute to ban a validator
+Method used to ban a validator, if the ban threshold is reached
 
-*This function will ban only if the input validator has reached the ban treshold*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| validator | address | Address of the validator |
-
-### banValidatorByOwner
-
-```solidity
-function banValidatorByOwner(address validator) external nonpayable
-```
-
-Manually ban a validator by the owner
-
-
+*This function will validate the threshold only if the executor is not the governor, otherwise will forcely ban the validator*
 
 #### Parameters
 

--- a/docs/ValidatorSet/modules/Inspector/Inspector.md
+++ b/docs/ValidatorSet/modules/Inspector/Inspector.md
@@ -127,15 +127,48 @@ Returns the total balance of a given validator
 |---|---|---|
 | _0 | uint256 | Validator&#39;s balance |
 
+### banTreshold
+
+```solidity
+function banTreshold() external view returns (uint256)
+```
+
+The block numbers threshold that needs to be passed to ban a validator
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### banValidator
 
 ```solidity
 function banValidator(address validator) external nonpayable
 ```
 
-Manual ban of a validator
+Public method where anyone can execute to ban a validator
 
-*Function can be executed only by the governor/owner*
+*This function will ban only if the input validator has reached the ban treshold*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+### banValidatorByOwner
+
+```solidity
+function banValidatorByOwner(address validator) external nonpayable
+```
+
+Manually ban a validator by the owner
+
+
 
 #### Parameters
 
@@ -208,6 +241,52 @@ function currentEpochId() external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
+
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
 
 ### getEpochByBlock
 
@@ -444,6 +523,22 @@ function rewardPool() external view returns (contract IRewardPool)
 |---|---|---|
 | _0 | contract IRewardPool | undefined |
 
+### setBanThreshold
+
+```solidity
+function setBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to ban a validator
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
 ### setCommission
 
 ```solidity
@@ -628,6 +723,45 @@ Unstakes amount for sender. Claims rewards beforehand.
 | Name | Type | Description |
 |---|---|---|
 | amount | uint256 | Amount to unstake |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+```
+
+A collection of the validators&#39; participation
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| activeFrom | uint256 | undefined |
+| lastlyActive | uint256 | undefined |
 
 ### validatorPenalty
 
@@ -1123,6 +1257,17 @@ error StakeRequirement(string src, string msg)
 |---|---|---|
 | src | string | undefined |
 | msg | string | undefined |
+
+### ThresholdNotReached
+
+```solidity
+error ThresholdNotReached()
+```
+
+
+
+
+
 
 ### Unauthorized
 

--- a/docs/ValidatorSet/modules/Inspector/Inspector.md
+++ b/docs/ValidatorSet/modules/Inspector/Inspector.md
@@ -133,7 +133,7 @@ Returns the total balance of a given validator
 function banTreshold() external view returns (uint256)
 ```
 
-The block numbers threshold that needs to be passed to ban a validator
+Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator
 
 
 
@@ -150,25 +150,9 @@ The block numbers threshold that needs to be passed to ban a validator
 function banValidator(address validator) external nonpayable
 ```
 
-Public method where anyone can execute to ban a validator
+Method used to ban a validator, if the ban threshold is reached
 
-*This function will ban only if the input validator has reached the ban treshold*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| validator | address | Address of the validator |
-
-### banValidatorByOwner
-
-```solidity
-function banValidatorByOwner(address validator) external nonpayable
-```
-
-Manually ban a validator by the owner
-
-
+*This function will validate the threshold only if the executor is not the governor, otherwise will forcely ban the validator*
 
 #### Parameters
 
@@ -730,7 +714,7 @@ Unstakes amount for sender. Claims rewards beforehand.
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -743,10 +727,10 @@ A function to update when the validator was lastly active
 ### validatorParticipation
 
 ```solidity
-function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+function validatorParticipation(address) external view returns (uint256)
 ```
 
-A collection of the validators&#39; participation
+Mapping that keeps the last time when a validator has participated in the consensus
 
 
 
@@ -760,8 +744,7 @@ A collection of the validators&#39; participation
 
 | Name | Type | Description |
 |---|---|---|
-| activeFrom | uint256 | undefined |
-| lastlyActive | uint256 | undefined |
+| _0 | uint256 | undefined |
 
 ### validatorPenalty
 

--- a/docs/ValidatorSet/modules/Inspector/Inspector.md
+++ b/docs/ValidatorSet/modules/Inspector/Inspector.md
@@ -127,10 +127,10 @@ Returns the total balance of a given validator
 |---|---|---|
 | _0 | uint256 | Validator&#39;s balance |
 
-### banTreshold
+### banThreshold
 
 ```solidity
-function banTreshold() external view returns (uint256)
+function banThreshold() external view returns (uint256)
 ```
 
 Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator

--- a/docs/ValidatorSet/modules/PowerExponent/PowerExponent.md
+++ b/docs/ValidatorSet/modules/PowerExponent/PowerExponent.md
@@ -110,6 +110,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -360,6 +406,22 @@ Set new pending exponent, to be activated in the next commit epoch
 | Name | Type | Description |
 |---|---|---|
 | newValue | uint256 | New Voting Power Exponent Numerator |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/PowerExponent/PowerExponent.md
+++ b/docs/ValidatorSet/modules/PowerExponent/PowerExponent.md
@@ -413,7 +413,7 @@ Set new pending exponent, to be activated in the next commit epoch
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -422,6 +422,28 @@ A function to update when the validator was lastly active
 | Name | Type | Description |
 |---|---|---|
 | validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Staking/BalanceState.md
+++ b/docs/ValidatorSet/modules/Staking/BalanceState.md
@@ -176,6 +176,22 @@ Returns the total supply
 |---|---|---|
 | _0 | uint256 | Total supply |
 
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
+
 
 
 ## Events

--- a/docs/ValidatorSet/modules/Staking/BalanceState.md
+++ b/docs/ValidatorSet/modules/Staking/BalanceState.md
@@ -182,7 +182,7 @@ Returns the total supply
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 

--- a/docs/ValidatorSet/modules/Staking/LiquidStaking.md
+++ b/docs/ValidatorSet/modules/Staking/LiquidStaking.md
@@ -83,6 +83,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -221,6 +267,22 @@ Returns the total supply
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | Total supply |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Staking/LiquidStaking.md
+++ b/docs/ValidatorSet/modules/Staking/LiquidStaking.md
@@ -274,7 +274,7 @@ Returns the total supply
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -283,6 +283,28 @@ A function to update when the validator was lastly active
 | Name | Type | Description |
 |---|---|---|
 | validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -193,6 +193,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -563,6 +609,45 @@ Unstakes amount for sender. Claims rewards beforehand.
 | Name | Type | Description |
 |---|---|---|
 | amount | uint256 | Amount to unstake |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+```
+
+A collection of the validators&#39; participation
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| activeFrom | uint256 | undefined |
+| lastlyActive | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Staking/Staking.md
+++ b/docs/ValidatorSet/modules/Staking/Staking.md
@@ -616,7 +616,7 @@ Unstakes amount for sender. Claims rewards beforehand.
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -629,10 +629,10 @@ A function to update when the validator was lastly active
 ### validatorParticipation
 
 ```solidity
-function validatorParticipation(address) external view returns (uint256 activeFrom, uint256 lastlyActive)
+function validatorParticipation(address) external view returns (uint256)
 ```
 
-A collection of the validators&#39; participation
+Mapping that keeps the last time when a validator has participated in the consensus
 
 
 
@@ -646,8 +646,7 @@ A collection of the validators&#39; participation
 
 | Name | Type | Description |
 |---|---|---|
-| activeFrom | uint256 | undefined |
-| lastlyActive | uint256 | undefined |
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Withdrawal/Withdrawal.md
+++ b/docs/ValidatorSet/modules/Withdrawal/Withdrawal.md
@@ -143,6 +143,52 @@ function currentEpochId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### epochEndBlocks
+
+```solidity
+function epochEndBlocks(uint256) external view returns (uint256)
+```
+
+Array with epoch ending blocks
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### epochs
+
+```solidity
+function epochs(uint256) external view returns (uint256 startBlock, uint256 endBlock, bytes32 epochRoot)
+```
+
+Epoch data linked with the epoch id
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| startBlock | uint256 | undefined |
+| endBlock | uint256 | undefined |
+| epochRoot | bytes32 | undefined |
+
 ### getEpochByBlock
 
 ```solidity
@@ -363,6 +409,22 @@ function transferOwnership(address newOwner) external nonpayable
 | Name | Type | Description |
 |---|---|---|
 | newOwner | address | undefined |
+
+### updateValidatorParticipation
+
+```solidity
+function updateValidatorParticipation(address validator) external nonpayable
+```
+
+A function to update when the validator was lastly active
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | The validator to set the last participation for |
 
 ### validators
 

--- a/docs/ValidatorSet/modules/Withdrawal/Withdrawal.md
+++ b/docs/ValidatorSet/modules/Withdrawal/Withdrawal.md
@@ -416,7 +416,7 @@ function transferOwnership(address newOwner) external nonpayable
 function updateValidatorParticipation(address validator) external nonpayable
 ```
 
-A function to update when the validator was lastly active
+Method to update when the validator was lastly active which can be executed only by the RewardPool
 
 
 
@@ -425,6 +425,28 @@ A function to update when the validator was lastly active
 | Name | Type | Description |
 |---|---|---|
 | validator | address | The validator to set the last participation for |
+
+### validatorParticipation
+
+```solidity
+function validatorParticipation(address) external view returns (uint256)
+```
+
+Mapping that keeps the last time when a validator has participated in the consensus
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### validators
 

--- a/test/RewardPool/RewardPool.test.ts
+++ b/test/RewardPool/RewardPool.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import * as hre from "hardhat";
 import { expect } from "chai";
 
-import { EPOCHS_YEAR, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
+import { EPOCHS_YEAR, ERRORS, MIN_RSI_BONUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
 import {
   calculateExpectedReward,
   commitEpoch,
@@ -460,7 +460,7 @@ export function RunVestedDelegateClaimTests(): void {
 
       await expect(
         vestManager.connect(this.signers.accounts[10]).claimVestedPositionReward(delegatedValidator.address, 0, 0)
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+      ).to.be.revertedWith(ERRORS.ownable);
     });
 
     it("should not claim when active position", async function () {

--- a/test/ValidatorSet/Delegation.test.ts
+++ b/test/ValidatorSet/Delegation.test.ts
@@ -61,12 +61,12 @@ export function RunDelegationTests(): void {
         .withArgs("delegate", "DELEGATING_AMOUNT_ZERO");
     });
 
-    it("should not be able to delegate to missing or inactive validator", async function () {
+    it("should not be able to delegate to  inactive validator", async function () {
       const { validatorSet } = await loadFixture(this.fixtures.withdrawableFixture);
 
       await expect(validatorSet.delegate(this.signers.validators[3].address, { value: this.minDelegation }))
         .to.be.revertedWithCustomError(validatorSet, "Unauthorized")
-        .withArgs("INVALID_VALIDATOR");
+        .withArgs(ERRORS.inactiveValidator);
     });
 
     it("should not be able to delegate less than minDelegation", async function () {
@@ -326,7 +326,7 @@ export function RunDelegationTests(): void {
             })
         )
           .to.be.revertedWithCustomError(validatorSet, "Unauthorized")
-          .withArgs("INVALID_VALIDATOR");
+          .withArgs(ERRORS.inactiveValidator);
       });
 
       it("should revert when delegation too low", async function () {
@@ -688,7 +688,7 @@ export function RunDelegationTests(): void {
           vestManager
             .connect(this.signers.accounts[10])
             .topUpVestedDelegatePosition(this.signers.accounts[10].address, { value: this.minDelegation })
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith(ERRORS.ownable);
       });
 
       it("should revert when not manager", async function () {

--- a/test/ValidatorSet/Inspector.test.ts
+++ b/test/ValidatorSet/Inspector.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-extraneous-import */
-import { loadFixture, time, setBalance, mineUpTo } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, time, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 
 import { expect } from "chai";
 import { DENOMINATOR, ERRORS, VALIDATOR_STATUS, VESTING_DURATION_WEEKS, WEEK } from "../constants";
@@ -176,12 +176,6 @@ export function RunInspectorTests(): void {
 
     it("should revert when the validator is active for long time and have not met the threshold", async function () {
       const { systemValidatorSet, rewardPool } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
-
-      const banThreshold = await systemValidatorSet.banTreshold();
-      // mine more blocks than the threshold
-      await mineUpTo(banThreshold.mul(2));
-
-      // const validators = [this.signers.validators[0], this.signers.validators[1]];
 
       // Commit epochs so we will have some rewards to be distributed
       await commitEpochs(

--- a/test/ValidatorSet/Inspector.test.ts
+++ b/test/ValidatorSet/Inspector.test.ts
@@ -57,7 +57,7 @@ export function RunInspectorTests(): void {
 
       const newBanThreshold = 100;
       await validatorSet.connect(this.signers.governance).setBanThreshold(newBanThreshold);
-      expect(await validatorSet.banTreshold()).to.be.equal(newBanThreshold);
+      expect(await validatorSet.banThreshold()).to.be.equal(newBanThreshold);
     });
   });
 
@@ -155,6 +155,7 @@ export function RunInspectorTests(): void {
 
       const reporterReward = await validatorSet.reporterReward();
       const validatorBanPenalty = await validatorSet.validatorPenalty();
+      const balanceToWithdrawFromContract = reporterReward.add(validatorBanPenalty);
       const withdrawalBalance = await validatorSet.withdrawalBalances(validatorToBan.address);
 
       expect(await validatorSet.balanceOf(validatorToBan.address), "balanceOf").to.be.equal(0);
@@ -164,8 +165,8 @@ export function RunInspectorTests(): void {
       );
       await expect(banTx, "StakeChanged").to.emit(validatorSet, "StakeChanged").withArgs(validatorToBan.address, 0);
       await expect(banTx, "withdrawn reward").to.changeEtherBalances(
-        [validatorSet.address, await validatorSet.signer.getAddress()],
-        [reporterReward.mul(-1), reporterReward]
+        [validatorSet.address, await validatorSet.signer.getAddress(), ethers.constants.AddressZero],
+        [balanceToWithdrawFromContract.mul(-1), reporterReward, validatorBanPenalty]
       );
     });
 
@@ -182,8 +183,8 @@ export function RunInspectorTests(): void {
 
       expect(withdrawalBalance.withdrawableAmount, "withdrawableAmount").to.be.equal(0);
       await expect(banTx, "withdrawn reward").to.changeEtherBalances(
-        [validatorSet.address, await validatorSet.signer.getAddress()],
-        [stakedAmount.mul(-1), stakedAmount]
+        [validatorSet.address, await validatorSet.signer.getAddress(), ethers.constants.AddressZero],
+        [stakedAmount.mul(-1), stakedAmount, 0]
       );
     });
 
@@ -201,8 +202,8 @@ export function RunInspectorTests(): void {
 
       expect(withdrawalBalance.withdrawableAmount, "withdrawableAmount").to.be.equal(0);
       await expect(banTx, "withdrawn reward").to.changeEtherBalances(
-        [validatorSet.address, await validatorSet.signer.getAddress()],
-        [reporterReward.mul(-1), reporterReward]
+        [validatorSet.address, await validatorSet.signer.getAddress(), ethers.constants.AddressZero],
+        [stakedAmount.mul(-1), reporterReward, stakedAmount.sub(reporterReward)]
       );
     });
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -23,7 +23,8 @@ export enum VALIDATOR_STATUS {
   None = 0,
   Whitelisted = 1,
   Registered = 2,
-  Banned = 3,
+  Active = 3,
+  Banned = 4,
 }
 
 /// @notice This bytecode is used to mock and return true with any input
@@ -34,6 +35,9 @@ export const alwaysFalseBytecode = "0x60206000F3";
 export const alwaysRevertBytecode = "0x60006000FD";
 
 export const ERRORS = {
+  ownable: "Ownable: caller is not the owner",
+  inactiveValidator: "INACTIVE_VALIDATOR",
+  invalidValidator: "INVALID_VALIDATOR",
   accessControl: (account: string, role: string) => {
     return `AccessControl: account ${account} is missing role ${role}`;
   },

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -431,8 +431,11 @@ async function validatorToBanFixtureFunction(this: Mocha.Context) {
     this.epochSize
   );
 
+  // lower the reporter reward in order to be able to distribute it
+  const reporterReward = this.minStake.div(10);
+  await validatorSetGov.setReporterReward(reporterReward);
   // lower the penalty in order to be able to penalize
-  await validatorSetGov.setValidatorPenalty(this.minStake.div(10));
+  await validatorSetGov.setValidatorPenalty(reporterReward.mul(2));
 
   return {
     validatorSet,
@@ -448,7 +451,7 @@ async function bannedValidatorFixtureFunction(this: Mocha.Context) {
   const validator = this.signers.validators[0];
   const stakedAmount = await validatorSet.balanceOf(validator.address);
 
-  await validatorSet.connect(this.signers.governance).banValidatorByOwner(validator.address);
+  await validatorSet.connect(this.signers.governance).banValidator(validator.address);
 
   return {
     validatorSet,

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 /* eslint-disable node/no-extraneous-import */
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { mine } from "@nomicfoundation/hardhat-network-helpers";
 import * as hre from "hardhat";
 import { BigNumber, ContractTransaction } from "ethers";
 
@@ -75,6 +76,8 @@ export async function commitEpoch(
   for (const validator of validators) {
     validatorsUptime.push({ validator: validator.address, signedBlocks: 64 });
   }
+
+  await mine(epochSize, { interval: 2 });
 
   const commitEpochTx = await systemValidatorSet.commitEpoch(currEpochId, newEpoch, epochSize);
 

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -155,6 +155,12 @@ export interface Fixtures {
       delegatedValidator: SignerWithAddress;
     }>;
   };
+  validatorToBanFixture: {
+    (): Promise<{
+      validatorSet: ValidatorSet;
+      validatorToBan: SignerWithAddress;
+    }>;
+  };
   bannedValidatorFixture: {
     (): Promise<{
       validatorSet: ValidatorSet;


### PR DESCRIPTION
- create the Participation struct and the mapping for the validator's participation;
- create a new status for active validator and activate it when initially stake;
- update the status check of the validator with active where applicable;
- set the activeFrom the current block number when activating the validator;
- create a new function in the ValidatorSet interface to update the lastlyActive for the validator participation;
- update the unstaking to take into account the delegation when unstaking the full amount;
- fix tests and write some new ones to cover the new changes;