### PR TITLE
163 integrate rewardwallet contract to hydra contract staking and delegation

### DIFF
--- a/contracts/HydraChain/HydraChain.sol
+++ b/contracts/HydraChain/HydraChain.sol
@@ -14,8 +14,6 @@ import {IHydraChain} from "./IHydraChain.sol";
 import {Uptime} from "./modules/ValidatorManager/IValidatorManager.sol";
 import {Epoch} from "./IHydraChain.sol";
 
-// TODO: setup use of reward account that would handle the amounts of rewards
-
 contract HydraChain is IHydraChain, Ownable2StepUpgradeable, ValidatorManager, Inspector, PowerExponent {
     using ArraysUpgradeable for uint256[];
 

--- a/contracts/HydraChain/modules/ValidatorManager/ValidatorManager.sol
+++ b/contracts/HydraChain/modules/ValidatorManager/ValidatorManager.sol
@@ -23,10 +23,14 @@ abstract contract ValidatorManager is
     uint256 public constant MAX_VALIDATORS = 150;
 
     IBLS public bls;
+
     address[] public validatorsAddresses;
+
     uint256 public activeValidatorsCount;
+
     // slither-disable-next-line naming-convention
     mapping(address => Validator) public validators;
+
     /**
      * @notice Mapping that keeps the last time when a validator has participated in the consensus
      * @dev Keep in mind that the validator will initially be set active when stake,

--- a/contracts/HydraDelegation/Delegation.sol
+++ b/contracts/HydraDelegation/Delegation.sol
@@ -26,7 +26,6 @@ contract Delegation is
 
     /// @notice Keeps the delegation pools
     mapping(address => DelegationPool) public delegationPools;
-
     // @note maybe this must be part of the HydraChain
     /// @notice The minimum delegation amount to be delegated
     uint256 public minDelegation;
@@ -35,9 +34,10 @@ contract Delegation is
 
     // _______________ Initializer _______________
 
-    function __Delegation_init(address _governace) internal onlyInitializing {
+    function __Delegation_init(address _governace, address _rewardWalletAddr) internal onlyInitializing {
         __Governed_init(_governace);
         __Withdrawal_init(_governace);
+        __RewardWalletConnector_init(_rewardWalletAddr);
         __Delegation_init_unchained();
     }
 

--- a/contracts/HydraDelegation/Delegation.sol
+++ b/contracts/HydraDelegation/Delegation.sol
@@ -6,10 +6,19 @@ import {Withdrawal} from "./../common/Withdrawal/Withdrawal.sol";
 import {APRCalculatorConnector} from "./../APRCalculator/APRCalculatorConnector.sol";
 import {HydraStakingConnector} from "./../HydraStaking/HydraStakingConnector.sol";
 import {HydraChainConnector} from "./../HydraChain/HydraChainConnector.sol";
+import {RewardWalletConnector} from "./../RewardWallet/RewardWalletConnector.sol";
 import {DelegationPoolLib} from "./DelegationPoolLib.sol";
 import {IDelegation, DelegationPool} from "./IDelegation.sol";
 
-contract Delegation is IDelegation, Governed, Withdrawal, APRCalculatorConnector, HydraStakingConnector, HydraChainConnector {
+contract Delegation is
+    IDelegation,
+    Governed,
+    Withdrawal,
+    APRCalculatorConnector,
+    HydraStakingConnector,
+    HydraChainConnector,
+    RewardWalletConnector
+{
     using DelegationPoolLib for DelegationPool;
 
     /// @notice A constant for the minimum delegation limit
@@ -17,6 +26,7 @@ contract Delegation is IDelegation, Governed, Withdrawal, APRCalculatorConnector
 
     /// @notice Keeps the delegation pools
     mapping(address => DelegationPool) public delegationPools;
+
     // @note maybe this must be part of the HydraChain
     /// @notice The minimum delegation amount to be delegated
     uint256 public minDelegation;
@@ -210,8 +220,8 @@ contract Delegation is IDelegation, Governed, Withdrawal, APRCalculatorConnector
         uint256 reward = aprCalculatorContract.applyBaseAPR(rewardIndex);
         if (reward == 0) return;
 
-        emit DelegatorRewardsClaimed(staker, delegator, reward);
+        rewardWalletContract.distributeReward(delegator, reward);
 
-        _withdraw(delegator, reward);
+        emit DelegatorRewardsClaimed(staker, delegator, reward);
     }
 }

--- a/contracts/HydraDelegation/HydraDelegation.sol
+++ b/contracts/HydraDelegation/HydraDelegation.sol
@@ -41,9 +41,9 @@ contract HydraDelegation is
     ) external initializer onlySystemCall {
         __APRCalculatorConnector_init(aprCalculatorAddr);
         __HydraStakingConnector_init(hydraStakingAddr);
-        __Delegation_init(governance);
+        __Delegation_init(governance, rewardWalletConnectorAddr);
         __LiquidDelegation_init(liquidToken);
-        __VestedDelegation_init(vestingManagerFactoryAddr, hydraChainAddr, rewardWalletConnectorAddr);
+        __VestedDelegation_init(vestingManagerFactoryAddr, hydraChainAddr);
 
         _initialize(initialStakers, initialCommission);
     }

--- a/contracts/HydraDelegation/HydraDelegation.sol
+++ b/contracts/HydraDelegation/HydraDelegation.sol
@@ -7,6 +7,7 @@ import {LiquidDelegation} from "./modules/LiquidDelegation/LiquidDelegation.sol"
 import {VestedDelegation} from "./modules/VestedDelegation/VestedDelegation.sol";
 import {APRCalculatorConnector} from "./../APRCalculator/APRCalculatorConnector.sol";
 import {HydraStakingConnector} from "./../HydraStaking/HydraStakingConnector.sol";
+import {RewardWalletConnector} from "./../RewardWallet/RewardWalletConnector.sol";
 import {IHydraDelegation} from "./IHydraDelegation.sol";
 import {StakerInit} from "./../HydraStaking/IHydraStaking.sol";
 
@@ -15,6 +16,7 @@ contract HydraDelegation is
     System,
     APRCalculatorConnector,
     HydraStakingConnector,
+    RewardWalletConnector,
     Delegation,
     LiquidDelegation,
     VestedDelegation
@@ -34,13 +36,14 @@ contract HydraDelegation is
         address aprCalculatorAddr,
         address hydraStakingAddr,
         address hydraChainAddr,
-        address vestingManagerFactoryAddr
+        address vestingManagerFactoryAddr,
+        address rewardWalletConnectorAddr
     ) external initializer onlySystemCall {
         __APRCalculatorConnector_init(aprCalculatorAddr);
         __HydraStakingConnector_init(hydraStakingAddr);
         __Delegation_init(governance);
         __LiquidDelegation_init(liquidToken);
-        __VestedDelegation_init(vestingManagerFactoryAddr, hydraChainAddr);
+        __VestedDelegation_init(vestingManagerFactoryAddr, hydraChainAddr, rewardWalletConnectorAddr);
 
         _initialize(initialStakers, initialCommission);
     }

--- a/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
@@ -12,12 +12,14 @@ import {IVestedDelegation, DelegationPoolParams, RPS} from "./IVestedDelegation.
 import {HydraChainConnector} from "./../../../HydraChain/HydraChainConnector.sol";
 import {VestingManagerFactoryConnector} from "./../../../VestingManager/VestingManagerFactoryConnector.sol";
 import {Vesting} from "./../../../common/Vesting/Vesting.sol";
+import {RewardWalletConnector} from "./../../../RewardWallet/RewardWalletConnector.sol";
 
 contract VestedDelegation is
     IVestedDelegation,
     Governed,
     Withdrawal,
     HydraChainConnector,
+    RewardWalletConnector,
     Delegation,
     VestingManagerFactoryConnector,
     Vesting
@@ -37,11 +39,6 @@ contract VestedDelegation is
     mapping(address => mapping(address => DelegationPoolParams[])) public delegationPoolParamsHistory;
 
     /**
-     * @notice The threshold for the maximum number of allowed balance changes
-     * @dev We are using this to restrict unlimited changes of the balance (delegationPoolParamsHistory)
-     */
-    uint256 public balanceChangeThreshold;
-    /**
      * @notice Keeps the history of the RPS for the stakers
      * @dev This is used to keep the history RPS in order to calculate properly the rewards
      */
@@ -51,14 +48,14 @@ contract VestedDelegation is
 
     // _______________ Initializer _______________
 
-    function __VestedDelegation_init(address _vestingManagerFactoryAddr, address _hydraChainAddr) internal onlyInitializing {
+    function __VestedDelegation_init(
+        address _vestingManagerFactoryAddr,
+        address _hydraChainAddr,
+        address _rewardWalletAddr
+    ) internal onlyInitializing {
         __VestingManagerFactoryConnector_init(_vestingManagerFactoryAddr);
         __HydraChainConnector_init(_hydraChainAddr);
-        __VestedDelegation_init_unchained();
-    }
-
-    function __VestedDelegation_init_unchained() internal onlyInitializing {
-        balanceChangeThreshold = 32;
+        __RewardWalletConnector_init(_rewardWalletAddr);
     }
 
     // _______________ Modifiers _______________
@@ -108,11 +105,7 @@ contract VestedDelegation is
     /**
      * @inheritdoc IVestedDelegation
      */
-    function getRPSValues(
-        address staker,
-        uint256 startEpoch,
-        uint256 endEpoch
-    ) external view returns (RPS[] memory) {
+    function getRPSValues(address staker, uint256 startEpoch, uint256 endEpoch) external view returns (RPS[] memory) {
         require(startEpoch <= endEpoch, "Invalid args");
 
         RPS[] memory values = new RPS[](endEpoch - startEpoch + 1);
@@ -232,11 +225,10 @@ contract VestedDelegation is
         uint256 delegatedAmount = delegation.balanceOf(msg.sender);
         uint256 delegatedAmountLeft = delegatedAmount - amount;
         uint256 penalty;
-        uint256 fullReward;
         if (position.isActive()) {
             penalty = _calcPenalty(position, amount);
-            // apply the max Vesting bonus, because the full reward must be burned
-            fullReward = aprCalculatorContract.applyMaxReward(delegation.claimRewards(msg.sender));
+            // claim rewards to increase the claimedRewards because the delegator lose its rewards
+            delegation.claimRewards(msg.sender);
 
             // if position is closed when active, we delete the vesting data
             if (delegatedAmountLeft == 0) {
@@ -258,7 +250,7 @@ contract VestedDelegation is
 
         _undelegate(staker, msg.sender, amount);
         uint256 amountAfterPenalty = amount - penalty;
-        _burnAmount(penalty + fullReward);
+        _burnAmount(penalty);
         _registerWithdrawal(msg.sender, amountAfterPenalty);
 
         emit PositionCut(msg.sender, staker, amountAfterPenalty);
@@ -267,19 +259,13 @@ contract VestedDelegation is
     /**
      * @inheritdoc IVestedDelegation
      */
-    function claimPositionReward(
-        address staker,
-        address to,
-        uint256 epochNumber,
-        uint256 balanceChangeIndex
-    ) external {
+    function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external {
         VestingPosition memory position = vestedDelegationPositions[staker][msg.sender];
         if (_noRewardConditions(position)) {
             return;
         }
 
         uint256 sumReward;
-        uint256 sumMaxReward;
         DelegationPool storage delegationPool = delegationPools[staker];
 
         // distribute the proper vesting reward
@@ -291,28 +277,19 @@ contract VestedDelegation is
         );
 
         uint256 reward = delegationPool.claimRewards(msg.sender, epochRPS, balance, correction);
-        uint256 maxReward = aprCalculatorContract.applyMaxReward(reward);
         reward = _applyVestingAPR(position, reward, true);
         sumReward += reward;
-        sumMaxReward += maxReward;
 
         // If the full maturing period is finished, withdraw also the reward made after the vesting period
         if (block.timestamp > position.end + position.duration) {
             uint256 additionalReward = delegationPool.claimRewards(msg.sender);
-            uint256 maxAdditionalReward = aprCalculatorContract.applyMaxReward(additionalReward);
             additionalReward = aprCalculatorContract.applyBaseAPR(additionalReward);
             sumReward += additionalReward;
-            sumMaxReward += maxAdditionalReward;
-        }
-
-        uint256 remainder = sumMaxReward - sumReward;
-        if (remainder > 0) {
-            _burnAmount(remainder);
         }
 
         if (sumReward == 0) return;
 
-        _withdraw(to, sumReward);
+        rewardWalletContract.distributeReward(to, sumReward);
 
         emit PositionRewardClaimed(msg.sender, staker, sumReward);
     }
@@ -340,7 +317,7 @@ contract VestedDelegation is
 
         uint256 duration = durationWeeks * 1 weeks;
         delete delegationPoolParamsHistory[staker][msg.sender];
-        // TODO: calculate end of period instead of write in in the cold storage. It is cheaper
+        // TODO: calculate end of period instead of write in the cold storage. It is cheaper
         vestedDelegationPositions[staker][msg.sender] = VestingPosition({
             duration: duration,
             start: block.timestamp,
@@ -389,16 +366,6 @@ contract VestedDelegation is
         }
 
         return false;
-    }
-
-    // TODO: Consider deleting it as we shouldn't be getting into that case
-    /**
-     * @notice Checks if the balance changes exceeds the threshold
-     * @param staker Validator to delegate to
-     * @param delegator Delegator that has delegated
-     */
-    function isBalanceChangeThresholdExceeded(address staker, address delegator) public view returns (bool) {
-        return delegationPoolParamsHistory[staker][delegator].length > balanceChangeThreshold;
     }
 
     /**
@@ -496,19 +463,10 @@ contract VestedDelegation is
      * @param delegator Address of the delegator
      * @param params Delegation pool params
      */
-    function _saveAccountParamsChange(
-        address staker,
-        address delegator,
-        DelegationPoolParams memory params
-    ) private {
+    function _saveAccountParamsChange(address staker, address delegator, DelegationPoolParams memory params) private {
         if (isBalanceChangeMade(staker, delegator, params.epochNum)) {
             // balance can be changed only once per epoch
             revert DelegateRequirement({src: "_saveAccountParamsChange", msg: "BALANCE_CHANGE_ALREADY_MADE"});
-        }
-
-        if (isBalanceChangeThresholdExceeded(staker, delegator)) {
-            // maximum amount of balance changes exceeded
-            revert DelegateRequirement({src: "_saveAccountParamsChange", msg: "BALANCE_CHANGES_EXCEEDED"});
         }
 
         delegationPoolParamsHistory[staker][delegator].push(params);

--- a/contracts/HydraStaking/IHydraStaking.sol
+++ b/contracts/HydraStaking/IHydraStaking.sol
@@ -16,12 +16,12 @@ struct StakerInit {
 interface IHydraStaking is IDelegatedStaking, IStaking, ILiquidStaking, IPenalizeableStaking {
     /**
      * @notice Distributes rewards for the given epoch
-     * @dev Transfers funds from sender to this contract
+     * @dev The function updates the rewards in the Staking and Delegation contracts' state
      * @param epochId The epoch number
      * @param uptime uptime data for every validator (staker)
      * @param epochSize Number of blocks per epoch
      */
-    function distributeRewardsFor(uint256 epochId, Uptime[] calldata uptime, uint256 epochSize) external payable;
+    function distributeRewardsFor(uint256 epochId, Uptime[] calldata uptime, uint256 epochSize) external;
 
     // _______________ Public functions _______________
 

--- a/contracts/HydraStaking/Staking.sol
+++ b/contracts/HydraStaking/Staking.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {IStaking, StakingReward} from "./IStaking.sol";
 import {Governed} from "./../common/Governed/Governed.sol";
 import {Withdrawal} from "./../common/Withdrawal/Withdrawal.sol";
-import {APRCalculatorConnector} from "./../APRCalculator/APRCalculatorConnector.sol";
 import {Unauthorized} from "./../common/Errors.sol";
-import {IStaking, StakingReward} from "./IStaking.sol";
+import {APRCalculatorConnector} from "./../APRCalculator/APRCalculatorConnector.sol";
+import {RewardWalletConnector} from "./../RewardWallet/RewardWalletConnector.sol";
 
-contract Staking is IStaking, Governed, Withdrawal, APRCalculatorConnector {
+contract Staking is IStaking, Governed, Withdrawal, APRCalculatorConnector, RewardWalletConnector {
     /// @notice A constant for the minimum stake limit
     uint256 public constant MIN_STAKE_LIMIT = 1 ether;
 
@@ -23,11 +24,13 @@ contract Staking is IStaking, Governed, Withdrawal, APRCalculatorConnector {
     function __Staking_init(
         uint256 _newMinStake,
         address _aprCalculatorAddr,
+        address _rewardWalletAddr,
         address _governance
     ) internal onlyInitializing {
         __Governed_init(_governance);
         __Withdrawal_init(_governance);
         __APRCalculatorConnector_init(_aprCalculatorAddr);
+        __RewardWalletConnector_init(_rewardWalletAddr);
         __Staking_init_unchained(_newMinStake);
     }
 
@@ -87,7 +90,7 @@ contract Staking is IStaking, Governed, Withdrawal, APRCalculatorConnector {
      * @inheritdoc IStaking
      */
     function claimStakingRewards() public {
-        _withdraw(msg.sender, _claimStakingRewards(msg.sender));
+        rewardWalletContract.distributeReward(msg.sender, _claimStakingRewards(msg.sender));
     }
 
     // _______________ Internal functions _______________

--- a/contracts/HydraStaking/modules/DelegatedStaking/DelegatedStaking.sol
+++ b/contracts/HydraStaking/modules/DelegatedStaking/DelegatedStaking.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {Staking} from "./../../Staking.sol";
-import {IHydraDelegation} from "./../../../HydraDelegation/IHydraDelegation.sol";
 import {IDelegatedStaking} from "./IDelegatedStaking.sol";
+import {Staking} from "./../../Staking.sol";
 import {Unauthorized} from "./../../../common/Errors.sol";
+import {IHydraDelegation} from "./../../../HydraDelegation/IHydraDelegation.sol";
 
 abstract contract DelegatedStaking is IDelegatedStaking, Staking {
     IHydraDelegation public delegationContract;
@@ -58,7 +58,6 @@ abstract contract DelegatedStaking is IDelegatedStaking, Staking {
      * @param staker The staker address
      */
     function _onUndelegate(address staker) internal virtual;
-
 
     /**
      * @notice Returns the total amount of delegation

--- a/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
@@ -87,9 +87,9 @@ contract VestedStaking is IVestedStaking, Staking, Vesting {
 
         stakingRewards[msg.sender].taken += rewards;
 
-        emit StakingRewardsClaimed(msg.sender, rewards);
+        rewardWalletContract.distributeReward(msg.sender, rewards);
 
-        _withdraw(msg.sender, rewards);
+        emit StakingRewardsClaimed(msg.sender, rewards);
     }
 
     // _______________ Internal functions _______________
@@ -106,7 +106,6 @@ contract VestedStaking is IVestedStaking, Staking, Vesting {
         (stakeLeft, withdrawAmount) = super._unstake(account, amount);
         VestingPosition memory position = vestedStakingPositions[account];
         if (position.isActive()) {
-            // TODO: Here the max reward index amount is not burned
             // staker lose its reward
             stakingRewards[account].taken = stakingRewards[account].total;
             uint256 penalty = _calcPenalty(position, amount);

--- a/docs/HydraDelegation/Delegation.md
+++ b/docs/HydraDelegation/Delegation.md
@@ -444,6 +444,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### supportsInterface
 
 ```solidity

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -191,6 +191,23 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
+### balanceChangeThreshold
+
+```solidity
+function balanceChangeThreshold() external view returns (uint256)
+```
+
+The threshold for the maximum number of allowed balance changes
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -731,6 +748,29 @@ Checks if balance change was already made in the current epoch
 | staker | address | Validator to delegate to |
 | delegator | address | Delegator that has delegated |
 | currentEpochNum | uint256 | Current epoch number |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### isBalanceChangeThresholdExceeded
+
+```solidity
+function isBalanceChangeThresholdExceeded(address staker, address delegator) external view returns (bool)
+```
+
+Checks if the balance changes exceeds the threshold
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Validator to delegate to |
+| delegator | address | Delegator that has delegated |
 
 #### Returns
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -191,23 +191,6 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
-### balanceChangeThreshold
-
-```solidity
-function balanceChangeThreshold() external view returns (uint256)
-```
-
-The threshold for the maximum number of allowed balance changes
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### calculatePositionPenalty
 
 ```solidity
@@ -687,7 +670,7 @@ function hydraStakingContract() external view returns (contract IHydraStaking)
 ### initialize
 
 ```solidity
-function initialize(StakerInit[] initialStakers, address governance, uint256 initialCommission, address liquidToken, address aprCalculatorAddr, address hydraStakingAddr, address hydraChainAddr, address vestingManagerFactoryAddr) external nonpayable
+function initialize(StakerInit[] initialStakers, address governance, uint256 initialCommission, address liquidToken, address aprCalculatorAddr, address hydraStakingAddr, address hydraChainAddr, address vestingManagerFactoryAddr, address rewardWalletConnectorAddr) external nonpayable
 ```
 
 
@@ -706,6 +689,7 @@ function initialize(StakerInit[] initialStakers, address governance, uint256 ini
 | hydraStakingAddr | address | undefined |
 | hydraChainAddr | address | undefined |
 | vestingManagerFactoryAddr | address | undefined |
+| rewardWalletConnectorAddr | address | undefined |
 
 ### isActiveDelegatePosition
 
@@ -747,29 +731,6 @@ Checks if balance change was already made in the current epoch
 | staker | address | Validator to delegate to |
 | delegator | address | Delegator that has delegated |
 | currentEpochNum | uint256 | Current epoch number |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bool | undefined |
-
-### isBalanceChangeThresholdExceeded
-
-```solidity
-function isBalanceChangeThresholdExceeded(address staker, address delegator) external view returns (bool)
-```
-
-Checks if the balance changes exceeds the threshold
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Validator to delegate to |
-| delegator | address | Delegator that has delegated |
 
 #### Returns
 
@@ -979,6 +940,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 |---|---|---|
 | role | bytes32 | undefined |
 | account | address | undefined |
+
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
 
 ### setCommission
 

--- a/docs/HydraDelegation/modules/LiquidDelegation/LiquidDelegation.md
+++ b/docs/HydraDelegation/modules/LiquidDelegation/LiquidDelegation.md
@@ -483,6 +483,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### supportsInterface
 
 ```solidity

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -72,6 +72,23 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
+### balanceChangeThreshold
+
+```solidity
+function balanceChangeThreshold() external view returns (uint256)
+```
+
+The threshold for the maximum number of allowed balance changes
+
+*We are using this to restrict unlimited changes of the balance (delegationPoolParamsHistory)*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -548,6 +565,29 @@ Checks if balance change was already made in the current epoch
 | staker | address | Validator to delegate to |
 | delegator | address | Delegator that has delegated |
 | currentEpochNum | uint256 | Current epoch number |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### isBalanceChangeThresholdExceeded
+
+```solidity
+function isBalanceChangeThresholdExceeded(address staker, address delegator) external view returns (bool)
+```
+
+Checks if the balance changes exceeds the threshold
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Validator to delegate to |
+| delegator | address | Delegator that has delegated |
 
 #### Returns
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -72,23 +72,6 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
-### balanceChangeThreshold
-
-```solidity
-function balanceChangeThreshold() external view returns (uint256)
-```
-
-The threshold for the maximum number of allowed balance changes
-
-*We are using this to restrict unlimited changes of the balance (delegationPoolParamsHistory)*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### calculatePositionPenalty
 
 ```solidity
@@ -572,29 +555,6 @@ Checks if balance change was already made in the current epoch
 |---|---|---|
 | _0 | bool | undefined |
 
-### isBalanceChangeThresholdExceeded
-
-```solidity
-function isBalanceChangeThresholdExceeded(address staker, address delegator) external view returns (bool)
-```
-
-Checks if the balance changes exceeds the threshold
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Validator to delegate to |
-| delegator | address | Delegator that has delegated |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bool | undefined |
-
 ### isMaturingDelegatePosition
 
 ```solidity
@@ -758,6 +718,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 |---|---|---|
 | role | bytes32 | undefined |
 | account | address | undefined |
+
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
 
 ### supportsInterface
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -277,7 +277,7 @@ function delegationContract() external view returns (contract IHydraDelegation)
 ### distributeRewardsFor
 
 ```solidity
-function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSize) external payable
+function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSize) external nonpayable
 ```
 
 
@@ -418,7 +418,7 @@ function hydraChainContract() external view returns (contract IHydraChain)
 ### initialize
 
 ```solidity
-function initialize(StakerInit[] initialStakers, address governance, uint256 newMinStake, address newLiquidToken, address hydraChainAddr, address aprCalculatorAddr, address delegationContractAddr) external nonpayable
+function initialize(StakerInit[] initialStakers, address governance, uint256 newMinStake, address newLiquidToken, address hydraChainAddr, address aprCalculatorAddr, address delegationContractAddr, address rewardWalletContractAddr) external nonpayable
 ```
 
 
@@ -436,6 +436,7 @@ function initialize(StakerInit[] initialStakers, address governance, uint256 new
 | hydraChainAddr | address | undefined |
 | aprCalculatorAddr | address | undefined |
 | delegationContractAddr | address | undefined |
+| rewardWalletContractAddr | address | undefined |
 
 ### leftToWithdrawPerStaker
 
@@ -664,6 +665,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 |---|---|---|
 | role | bytes32 | undefined |
 | account | address | undefined |
+
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
 
 ### stake
 

--- a/docs/HydraStaking/IHydraStaking.md
+++ b/docs/HydraStaking/IHydraStaking.md
@@ -56,7 +56,7 @@ Claims staking rewards for the sender.
 ### distributeRewardsFor
 
 ```solidity
-function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSize) external payable
+function distributeRewardsFor(uint256 epochId, Uptime[] uptime, uint256 epochSize) external nonpayable
 ```
 
 

--- a/docs/HydraStaking/Staking.md
+++ b/docs/HydraStaking/Staking.md
@@ -295,6 +295,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/docs/HydraStaking/modules/DelegatedStaking/DelegatedStaking.md
+++ b/docs/HydraStaking/modules/DelegatedStaking/DelegatedStaking.md
@@ -344,6 +344,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/docs/HydraStaking/modules/LiquidStaking/LiquidStaking.md
+++ b/docs/HydraStaking/modules/LiquidStaking/LiquidStaking.md
@@ -334,6 +334,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/docs/HydraStaking/modules/PenalizeableStaking/PenalizeableStaking.md
+++ b/docs/HydraStaking/modules/PenalizeableStaking/PenalizeableStaking.md
@@ -351,6 +351,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/docs/HydraStaking/modules/StateSyncStaking/StateSyncStaking.md
+++ b/docs/HydraStaking/modules/StateSyncStaking/StateSyncStaking.md
@@ -295,6 +295,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -357,6 +357,23 @@ function revokeRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### rewardWalletContract
+
+```solidity
+function rewardWalletContract() external view returns (contract IRewardWallet)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IRewardWallet | undefined |
+
 ### stake
 
 ```solidity

--- a/test/HydraStaking/HydraStaking.test.ts
+++ b/test/HydraStaking/HydraStaking.test.ts
@@ -378,28 +378,31 @@ export function RunHydraStakingTests(): void {
       });
     });
 
+    // TODO: add some more coverage here, like in the HydraDelegation's claim rewards
     describe("Claim Rewards", function () {
       it("should claim validator reward", async function () {
         const { systemHydraChain, hydraStaking } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
 
+        const rewardingValidator = this.signers.validators[0];
+
         await commitEpoch(
           systemHydraChain,
           hydraStaking,
-          [this.signers.validators[0], this.signers.validators[1]],
+          [rewardingValidator, this.signers.validators[1]],
           this.epochSize
         );
 
-        const reward = await hydraStaking.unclaimedRewards(this.signers.validators[0].address);
-        const tx = await hydraStaking.connect(this.signers.validators[0])["claimStakingRewards()"]();
+        const reward = await hydraStaking.unclaimedRewards(rewardingValidator.address);
+        const tx = await hydraStaking.connect(rewardingValidator)["claimStakingRewards()"]();
         const receipt = await tx.wait();
 
         const event = receipt.events?.find((log: any) => log.event === "StakingRewardsClaimed");
-        expect(event?.args?.account, "event.arg.account").to.equal(this.signers.validators[0].address);
+        expect(event?.args?.account, "event.arg.account").to.equal(rewardingValidator.address);
         expect(event?.args?.amount, "event.arg.amount").to.equal(reward);
 
         await expect(tx, "StakingRewardsClaimed")
           .to.emit(hydraStaking, "StakingRewardsClaimed")
-          .withArgs(this.signers.validators[0].address, reward);
+          .withArgs(rewardingValidator.address, reward);
       });
     });
 

--- a/test/RewardWallet/RewardWallet.test.ts
+++ b/test/RewardWallet/RewardWallet.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 /* eslint-disable node/no-extraneous-import */
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 
 import { ERRORS } from "../constants";
@@ -68,6 +68,32 @@ export function RunRewardWalletTests(): void {
       await expect(rewardWallet.distributeReward(this.signers.validators[0].address, this.minStake))
         .to.be.revertedWithCustomError(rewardWallet, ERRORS.unauthorized.name)
         .withArgs("ONLY_MANAGER");
+    });
+
+    it("should revert when distribution is failing", async function () {
+      const { systemHydraChain, hydraStaking, rewardWallet } = await loadFixture(
+        this.fixtures.stakedValidatorsStateFixture
+      );
+
+      const rewardingValidator = this.signers.validators[0];
+
+      // commit some epochs in order to distribute rewards
+      await commitEpochs(
+        systemHydraChain,
+        hydraStaking,
+        [rewardingValidator, this.signers.validators[1]],
+        3,
+        this.epochSize
+      );
+
+      await setBalance(rewardWallet.address, 0);
+      const balance = await ethers.provider.getBalance(rewardWallet.address);
+      expect(balance, "rewardWallet balance").to.equal(0);
+
+      await expect(
+        hydraStaking.connect(rewardingValidator)["claimStakingRewards()"](),
+        "DistributionFailed"
+      ).to.be.revertedWithCustomError(rewardWallet, "DistributionFailed");
     });
 
     it("should successfully distribute reward", async function () {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -16,14 +16,7 @@ import {
   VestingManagerFactory__factory,
 } from "../typechain-types";
 import { CHAIN_ID, DOMAIN, INITIAL_COMMISSION, MIN_RSI_BONUS, SYSTEM, VESTING_DURATION_WEEKS, WEEK } from "./constants";
-import {
-  getMaxEpochReward,
-  commitEpochs,
-  registerValidator,
-  createNewVestManager,
-  generateValidatorBls,
-  commitEpoch,
-} from "./helper";
+import { commitEpochs, registerValidator, createNewVestManager, generateValidatorBls, commitEpoch } from "./helper";
 
 // --------------- Deploying Contracts ---------------
 
@@ -179,7 +172,8 @@ async function initializedHydraChainStateFixtureFunction(this: Mocha.Context) {
       liquidToken.address,
       hydraChain.address,
       aprCalculator.address,
-      hydraDelegation.address
+      hydraDelegation.address,
+      rewardWallet.address
     );
 
   await hydraDelegation
@@ -192,7 +186,8 @@ async function initializedHydraChainStateFixtureFunction(this: Mocha.Context) {
       aprCalculator.address,
       hydraStaking.address,
       hydraChain.address,
-      vestingManagerFactory.address
+      vestingManagerFactory.address,
+      rewardWallet.address
     );
 
   await vestingManagerFactory.connect(this.signers.system).initialize(hydraDelegation.address);
@@ -247,10 +242,7 @@ async function commitEpochTxFixtureFunction(this: Mocha.Context) {
     },
   ];
   const commitEpochTx = await systemHydraChain.commitEpoch(epochId, epoch, this.epochSize, uptime);
-  const maxReward = await getMaxEpochReward(hydraStaking);
-  await hydraStaking.connect(this.signers.system).distributeRewardsFor(epochId, uptime, this.epochSize, {
-    value: maxReward,
-  });
+  await hydraStaking.connect(this.signers.system).distributeRewardsFor(epochId, uptime, this.epochSize);
 
   return {
     hydraChain,
@@ -464,6 +456,7 @@ async function newVestingValidatorFixtureFunction(this: Mocha.Context) {
     aprCalculator,
     liquidToken,
     vestingManagerFactory,
+    rewardWallet,
   } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
 
   const staker = this.signers.accounts[9];
@@ -493,6 +486,7 @@ async function newVestingValidatorFixtureFunction(this: Mocha.Context) {
     liquidToken,
     aprCalculator,
     vestingManagerFactory,
+    rewardWallet,
   };
 }
 
@@ -506,6 +500,7 @@ async function vestingRewardsFixtureFunction(this: Mocha.Context) {
     aprCalculator,
     liquidToken,
     vestingManagerFactory,
+    rewardWallet,
   } = await loadFixture(this.fixtures.newVestingValidatorFixture);
 
   const staker = this.signers.accounts[9];
@@ -537,6 +532,7 @@ async function vestingRewardsFixtureFunction(this: Mocha.Context) {
     aprCalculator,
     liquidToken,
     vestingManagerFactory,
+    rewardWallet,
   };
 }
 
@@ -552,6 +548,7 @@ async function withdrawableFixtureFunction(this: Mocha.Context) {
     liquidToken,
     vestingManagerFactory,
     aprCalculator,
+    rewardWallet,
   } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
 
   const unstakedValidator = this.signers.validators[0];
@@ -580,6 +577,7 @@ async function withdrawableFixtureFunction(this: Mocha.Context) {
     unstakedAmount,
     vestingManagerFactory,
     aprCalculator,
+    rewardWallet,
   };
 }
 
@@ -595,6 +593,7 @@ async function delegatedFixtureFunction(this: Mocha.Context) {
     liquidToken,
     vestingManagerFactory,
     aprCalculator,
+    rewardWallet,
   } = await loadFixture(this.fixtures.withdrawableFixture);
 
   const delegateAmount = this.minDelegation.mul(2);
@@ -620,6 +619,7 @@ async function delegatedFixtureFunction(this: Mocha.Context) {
     liquidToken,
     vestingManagerFactory,
     aprCalculator,
+    rewardWallet,
   };
 }
 
@@ -633,6 +633,7 @@ async function vestManagerFixtureFunction(this: Mocha.Context) {
     liquidToken,
     vestingManagerFactory,
     aprCalculator,
+    rewardWallet,
   } = await loadFixture(this.fixtures.delegatedFixture);
 
   const { newManagerFactory, newManager } = await createNewVestManager(vestingManagerFactory, this.signers.accounts[4]);
@@ -648,6 +649,7 @@ async function vestManagerFixtureFunction(this: Mocha.Context) {
     vestManagerOwner: this.signers.accounts[4],
     vestingManagerFactory: newManagerFactory,
     aprCalculator,
+    rewardWallet,
   };
 }
 
@@ -662,6 +664,7 @@ async function vestedDelegationFixtureFunction(this: Mocha.Context) {
     vestingManagerFactory,
     vestManager,
     vestManagerOwner,
+    rewardWallet,
   } = await loadFixture(this.fixtures.vestManagerFixture);
 
   const validator = this.signers.validators[2];
@@ -689,6 +692,7 @@ async function vestedDelegationFixtureFunction(this: Mocha.Context) {
     vestManager,
     vestManagerOwner,
     delegatedValidator: validator,
+    rewardWallet,
   };
 }
 
@@ -704,6 +708,7 @@ async function weeklyVestedDelegationFixtureFunction(this: Mocha.Context) {
     vestManager,
     vestManagerOwner,
     aprCalculator,
+    rewardWallet,
   } = await loadFixture(this.fixtures.vestManagerFixture);
 
   const validator = this.signers.validators[2];
@@ -733,6 +738,7 @@ async function weeklyVestedDelegationFixtureFunction(this: Mocha.Context) {
     vestManagerOwner,
     delegatedValidator: validator,
     aprCalculator,
+    rewardWallet,
   };
 }
 

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -83,7 +83,7 @@ export async function commitEpoch(
 
   const validatorsUptime = [];
   for (const validator of validators) {
-    validatorsUptime.push({ validator: validator.address, signedBlocks: 64 });
+    validatorsUptime.push({ validator: validator.address, signedBlocks: epochSize });
   }
 
   await mine(epochSize, { interval: 2 });

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -92,12 +92,9 @@ export async function commitEpoch(
 
   const commitEpochTx = await systemHydraChain.commitEpoch(currEpochId, newEpoch, epochSize, validatorsUptime);
 
-  const maxReward = await getMaxEpochReward(hydraStaking);
   const distributeRewardsTx = await hydraStaking
     .connect(systemHydraChain.signer)
-    .distributeRewardsFor(currEpochId, validatorsUptime, epochSize, {
-      value: maxReward,
-    });
+    .distributeRewardsFor(currEpochId, validatorsUptime, epochSize);
 
   return { commitEpochTx, distributeRewardsTx };
 }

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -120,6 +120,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      rewardWallet: RewardWallet;
     }>;
   };
   vestingRewardsFixture: {
@@ -131,6 +132,7 @@ export interface Fixtures {
       hydraStaking: HydraStaking;
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
+      rewardWallet: RewardWallet;
     }>;
   };
   withdrawableFixture: {
@@ -145,6 +147,7 @@ export interface Fixtures {
       unstakedAmount: BigNumber;
       vestingManagerFactory: VestingManagerFactory;
       aprCalculator: APRCalculator;
+      rewardWallet: RewardWallet;
     }>;
   };
   delegatedFixture: {
@@ -157,6 +160,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       vestingManagerFactory: VestingManagerFactory;
       aprCalculator: APRCalculator;
+      rewardWallet: RewardWallet;
     }>;
   };
   vestManagerFixture: {
@@ -171,6 +175,7 @@ export interface Fixtures {
       vestManagerOwner: SignerWithAddress;
       vestingManagerFactory: VestingManagerFactory;
       aprCalculator: APRCalculator;
+      rewardWallet: RewardWallet;
     }>;
   };
   vestedDelegationFixture: {
@@ -185,6 +190,7 @@ export interface Fixtures {
       vestManager: VestingManager;
       vestManagerOwner: SignerWithAddress;
       delegatedValidator: SignerWithAddress;
+      rewardWallet: RewardWallet;
     }>;
   };
   weeklyVestedDelegationFixture: {
@@ -200,6 +206,7 @@ export interface Fixtures {
       vestManagerOwner: SignerWithAddress;
       delegatedValidator: SignerWithAddress;
       aprCalculator: APRCalculator;
+      rewardWallet: RewardWallet;
     }>;
   };
   validatorToBanFixture: {


### PR DESCRIPTION
- remove the payability of Hydra distributeRewardsFor function;
- remove all the burning of the remaining reward;
- integrated the RewardWallet contract for the distribution of the rewards;
- adapt the tests to the changes;
- add test to cover the DistributionFailed error
- delete some todo comments because they were covered by the changes;