### PR TITLE
181 implement a priceoracle contract

### DIFF
--- a/contracts/APRCalculator/APRCalculator.sol
+++ b/contracts/APRCalculator/APRCalculator.sol
@@ -17,9 +17,10 @@ contract APRCalculator is IAPRCalculator, MacroFactor, RSIndex {
     function initialize(
         address governance,
         address hydraChainAddr,
+        address priceOracleAddr,
         uint256[310] memory prices
     ) external initializer onlySystemCall {
-        __Price_init(hydraChainAddr, governance, prices);
+        __Price_init(hydraChainAddr, priceOracleAddr, governance, prices);
         __MacroFactor_init();
         __RSIndex_init();
 

--- a/contracts/APRCalculator/modules/Price/IPrice.sol
+++ b/contracts/APRCalculator/modules/Price/IPrice.sol
@@ -2,20 +2,19 @@
 pragma solidity 0.8.17;
 
 interface IPrice {
-    event PriceQuoted(uint256 indexed epochId, uint256 amount);
-    event PriceUpdated(uint256 time, uint256 price);
+    event PriceUpdated(uint256 day, uint256 price);
 
     error GuardAlreadyDisabled();
     error GuardAlreadyEnabled();
-    error PriceAlreadyQuoted();
-    error InvalidPrice();
+    error PriceAlreadySet();
 
     /**
-     * @notice Quotes the price for each epoch & keeps the average price for each day
-     * @dev only the system can call this function
-     * @param price the amount to quote
+     * @notice Updates the price for the last day
+     * @dev only the PriceOracle can call this function
+     * @param price the price to be updated
+     * @param day the day to be updated
      */
-    function quotePrice(uint256 price) external;
+    function updatePrice(uint256 price, uint256 day) external;
 
     /**
      * @notice Protects RSI bonus and Macro factor updates and set them to default values

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -12,8 +12,7 @@ interface IPriceOracle {
     event PriceUpdated(uint256 price, uint256 day);
 
     error InvalidPrice();
-    error AlreadyVoted();
-    error PriceAlreadySet();
+    error InvalidVote(string message);
 
     /**
      * @notice Allows active validators to vote on the price
@@ -28,6 +27,7 @@ interface IPriceOracle {
      * @notice Returns true if the validator can vote for the provided day
      * @param day The day to check
      * @return true if the validator can vote
+     * @return error message if the validator cannot vote
      */
-    function shouldVote(uint256 day) external view returns (bool);
+    function shouldVote(uint256 day) external view returns (bool, string memory);
 }

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -18,7 +18,16 @@ interface IPriceOracle {
     /**
      * @notice Allows active validators to vote on the price
      * @dev it automatically updates the price if all conditions are met
-     * @param _price Price to vote
+     * @param price Price to vote
      */
-    function vote(uint256 _price) external;
+    function vote(uint256 price) external;
+
+    // _______________ Public functions _______________
+
+    /**
+     * @notice Returns true if the validator can vote for the provided day
+     * @param day The day to check
+     * @return true if the validator can vote
+     */
+    function isValidValidatorVote(uint256 day) external view returns (bool);
 }

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -8,8 +8,10 @@ struct PriceForValidator {
 
 interface IPriceOracle {
     event PriceVoted(uint256 price, address validator, uint256 day);
+    event PriceUpdateFailed(uint256 price, uint256 day, bytes data);
     event PriceUpdated(uint256 price, uint256 day);
 
+    error InvalidPrice();
     error AlreadyVoted();
     error PriceAlreadySet();
 

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -29,5 +29,5 @@ interface IPriceOracle {
      * @param day The day to check
      * @return true if the validator can vote
      */
-    function isValidValidatorVote(uint256 day) external view returns (bool);
+    function shouldVote(uint256 day) external view returns (bool);
 }

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -1,4 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-interface IPriceOracle {}
+struct PriceForValidator {
+    uint256 price;
+    address validator;
+}
+
+interface IPriceOracle {
+    event PriceVoted(uint256 price, address validator, uint256 day);
+    event PriceUpdated(uint256 price, uint256 day);
+
+    error AlreadyVoted();
+    error PriceAlreadySet();
+
+    /**
+     * @notice Allows active validators to vote on the price
+     * @dev it automatically updates the price if all conditions are met
+     * @param _price Price to vote
+     */
+    function vote(uint256 _price) external;
+}

--- a/contracts/PriceOracle/IPriceOracle.sol
+++ b/contracts/PriceOracle/IPriceOracle.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IPriceOracle {}

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {Unauthorized} from "../common/Errors.sol";
+import {System} from "../common/System/System.sol";
+import {IPriceOracle} from "./IPriceOracle.sol";
+
+/**
+ * @title PriceOracle
+ * @dev This contract will be responsible for the price updates.
+ * Active validators will be able to vote and agree on the price.
+ */
+contract PriceOracle is IPriceOracle, System, Initializable {
+    // _______________ Initializer _______________
+
+    function initialize() external initializer onlySystemCall {}
+
+    function _initialize() internal onlyInitializing {}
+
+    // slither-disable-next-line unused-state,naming-convention
+    uint256[50] private __gap;
+}

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -24,10 +24,7 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
     function initialize(address _hydraChainAddr, address _aprCalculatorAddr) external initializer onlySystemCall {
         __HydraChainConnector_init(_hydraChainAddr);
         __APRCalculatorConnector_init(_aprCalculatorAddr);
-        _initialize();
     }
-
-    function _initialize() private onlyInitializing {}
 
     // _______________ Modifers _______________
 
@@ -132,12 +129,10 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
      * @param _price Price to be updated
      */
     function _updatePrice(uint256 _price, uint256 _day) private {
-        pricePerDay[_day] = _price;
-        // sami: should update price, not quote
-        try aprCalculatorContract.quotePrice(_price) {
+        try aprCalculatorContract.updatePrice(_price, _day) {
+            pricePerDay[_day] = _price;
             emit PriceUpdated(_price, _day);
         } catch (bytes memory error) {
-            emit PriceUpdated(_price, _day); // sami: remove this line when finish Price module update
             emit PriceUpdateFailed(_price, _day, error);
         }
     }

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -19,18 +19,13 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
     mapping(address => uint256) public validatorLastVotedDay;
     mapping(uint256 => uint256) public pricePerDay;
 
-    uint256 public votingPowerPercentageNeeded;
+    uint256 public constant VOTING_POWER_PERCENTAGE_NEEDED = 61;
 
     // _______________ Initializer _______________
 
     function initialize(address _hydraChainAddr, address _aprCalculatorAddr) external initializer onlySystemCall {
         __HydraChainConnector_init(_hydraChainAddr);
         __APRCalculatorConnector_init(_aprCalculatorAddr);
-        _initialize();
-    }
-
-    function _initialize() private onlyInitializing {
-        votingPowerPercentageNeeded = 61;
     }
 
     // _______________ External functions _______________
@@ -44,7 +39,6 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
         }
 
         uint256 day = _getCurrentDay();
-
         (bool canVote, string memory errMsg) = shouldVote(day);
         if (!canVote) {
             revert InvalidVote(errMsg);
@@ -57,7 +51,7 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
 
         emit PriceVoted(price, msg.sender, day);
 
-        uint256 availablePrice = _checkPriceUpdateAvailability(day);
+        uint256 availablePrice = _calcPriceWithQuorum(day);
 
         if (availablePrice != 0) {
             _updatePrice(availablePrice, day);
@@ -70,8 +64,8 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
      * @inheritdoc IPriceOracle
      */
     function shouldVote(uint256 day) public view returns (bool, string memory) {
-        if (hydraChainContract.isValidatorActive(msg.sender) == false) {
-            return (false, "INACTIVE_STAKER");
+        if (hydraChainContract.getValidatorPower(msg.sender) == 0) {
+            return (false, "VALIDATOR_WITHOUT_POWER");
         }
 
         if (pricePerDay[day] != 0) {
@@ -92,7 +86,7 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
      * @param day Day to check
      * @return uint256 Price if available, 0 otherwise
      */
-    function _checkPriceUpdateAvailability(uint256 day) internal view returns (uint256) {
+    function _calcPriceWithQuorum(uint256 day) internal view returns (uint256) {
         PriceForValidator[] memory prices = priceVotesForDay[day];
         uint256 len = prices.length;
 
@@ -100,7 +94,7 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
             return 0; // Not enough votes to determine
         }
 
-        uint256 neededVotingPower = (hydraChainContract.getTotalVotingPower() * votingPowerPercentageNeeded) / 100;
+        uint256 neededVotingPower = (hydraChainContract.getTotalVotingPower() * VOTING_POWER_PERCENTAGE_NEEDED) / 100;
 
         // Sort prices in ascending order
         for (uint256 i = 0; i < len - 1; i++) {
@@ -114,47 +108,22 @@ contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector
         }
 
         // Check for suitable price
-        uint256 baseIndex = 0;
-        uint256 basePrice = 0;
-        uint256 totalPrice = 0;
-        uint256 count = 0;
+        uint256 avrPrice = 0;
         uint256 powerSum = 0;
         for (uint256 i = 0; i < len; i++) {
             uint256 currentPriceIndex = prices[i].price;
-            if (currentPriceIndex > (basePrice * 101) / 100) {
-                bool prevousIndexFound = false;
-                // Check if there is a previous index that is within 1% range with the current price index
-                if (count > 2) {
-                    for (uint256 j = baseIndex + 1; j < i; j++) {
-                        if (currentPriceIndex <= (prices[j].price * 101) / 100) {
-                            prevousIndexFound = true;
-                            count = 1;
-                            baseIndex = j;
-                            basePrice = prices[j].price;
-                            totalPrice = prices[j].price;
-                            powerSum = hydraChainContract.getValidatorPower(prices[j].validator);
-                            break;
-                        }
-                    }
-                }
-
-                if (!prevousIndexFound) {
-                    // If price all previous prices are outside 1% range, start a new group
-                    count = 1;
-                    baseIndex = i;
-                    basePrice = currentPriceIndex;
-                    totalPrice = currentPriceIndex;
-                    powerSum = hydraChainContract.getValidatorPower(prices[i].validator);
-                }
+            if (currentPriceIndex > (avrPrice * 101) / 100) {
+                // If price is outside 1% range, start a new group
+                avrPrice = currentPriceIndex;
+                powerSum = hydraChainContract.getValidatorPower(prices[i].validator);
             } else {
                 // If price is within 1% range, add it to the group
-                count++;
-                totalPrice += currentPriceIndex;
+                avrPrice = (avrPrice + currentPriceIndex) / 2;
                 powerSum += hydraChainContract.getValidatorPower(prices[i].validator);
             }
 
             if (powerSum >= neededVotingPower) {
-                return totalPrice / count; // Return the average price of the group
+                return avrPrice; // Return the average price of the group
             }
         }
 

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -5,6 +5,8 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 
 import {Unauthorized} from "../common/Errors.sol";
 import {System} from "../common/System/System.sol";
+import {HydraChainConnector} from "../HydraChain/HydraChainConnector.sol";
+import {APRCalculatorConnector} from "../APRCalculator/APRCalculatorConnector.sol";
 import {IPriceOracle} from "./IPriceOracle.sol";
 
 /**
@@ -12,12 +14,70 @@ import {IPriceOracle} from "./IPriceOracle.sol";
  * @dev This contract will be responsible for the price updates.
  * Active validators will be able to vote and agree on the price.
  */
-contract PriceOracle is IPriceOracle, System, Initializable {
+contract PriceOracle is IPriceOracle, System, Initializable, HydraChainConnector, APRCalculatorConnector {
+    mapping(address => uint256) public validatorVotedForDay;
+    mapping(uint256 => uint256[]) public priceVotesForDay;
+
     // _______________ Initializer _______________
 
-    function initialize() external initializer onlySystemCall {}
+    function initialize(address _hydraChainAddr, address _aprCalculatorAddr) external initializer onlySystemCall {
+        __HydraChainConnector_init(_hydraChainAddr);
+        __APRCalculatorConnector_init(_aprCalculatorAddr);
+        _initialize();
+    }
 
-    function _initialize() internal onlyInitializing {}
+    function _initialize() private onlyInitializing {}
+
+    // _______________ External functions _______________
+
+    function vote(uint256 _price) external {
+        if (hydraChainContract.isValidatorActive(msg.sender) == false) {
+            revert Unauthorized("ONLY_ACTIVE_VALIDATOR");
+        }
+
+        _vote(_price);
+    }
+
+    // _______________ Internal functions _______________
+
+    function _vote(uint256 _price) internal {
+        uint256 day = _getCurrentDay();
+        if (validatorVotedForDay[msg.sender] == day) {
+            revert Unauthorized("ALREADY_VOTED");
+        }
+
+        validatorVotedForDay[msg.sender] = day;
+        priceVotesForDay[day].push(_price);
+
+        if (priceVotesForDay[day].length != 4 || /** quorum < 0.61 */ true) {
+            return;
+        } else {
+            _updatePrice(day);
+        }
+
+        aprCalculatorContract.quotePrice(_price);
+    }
+
+    // _______________ Private functions _______________
+
+    function _updatePrice(uint256 _day) private {
+        uint256[] memory prices = priceVotesForDay[_day];
+        uint256 sum = 0;
+        for (uint256 i = 0; i < prices.length; i++) {
+            sum += prices[i];
+        }
+
+        uint256 price = sum / prices.length;
+        if (price * 100 > prices[0] * 101 || price * 100 < prices[0] * 99) {
+            revert Unauthorized("PRICE_MISMATCH");
+        }
+
+        aprCalculatorContract.quotePrice(price);
+    }
+
+    function _getCurrentDay() private view returns (uint256) {
+        return block.timestamp / 1 days;
+    }
 
     // slither-disable-next-line unused-state,naming-convention
     uint256[50] private __gap;

--- a/contracts/PriceOracle/PriceOracleConnector.sol
+++ b/contracts/PriceOracle/PriceOracleConnector.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {Unauthorized} from "../common/Errors.sol";
+import {IPriceOracle} from "./IPriceOracle.sol";
+
+abstract contract PriceOracleConnector is Initializable {
+    IPriceOracle public priceOracleContract;
+
+    // _______________ Initializer _______________
+
+    function __PriceOracleConnector_init(address _priceOracleAddr) internal onlyInitializing {
+        __PriceOracleConnector_init_unchained(_priceOracleAddr);
+    }
+
+    function __PriceOracleConnector_init_unchained(address _priceOracleAddr) internal onlyInitializing {
+        priceOracleContract = IPriceOracle(_priceOracleAddr);
+    }
+
+    // _______________ Modifiers _______________
+
+    modifier onlyPriceOracle() {
+        if (msg.sender != address(priceOracleContract)) {
+            revert Unauthorized("ONLY_PRICE_ORACLE");
+        }
+
+        _;
+    }
+}

--- a/contracts/RewardWallet/RewardWallet.sol
+++ b/contracts/RewardWallet/RewardWallet.sol
@@ -27,7 +27,7 @@ contract RewardWallet is IRewardWallet, System, Initializable {
         _initialize(managers);
     }
 
-    function _initialize(address[] calldata managers) internal onlyInitializing {
+    function _initialize(address[] calldata managers) private onlyInitializing {
         for (uint256 i = 0; i < managers.length; i++) {
             rewardManagers[managers[i]] = true;
         }

--- a/docs/APRCalculator/APRCalculator.md
+++ b/docs/APRCalculator/APRCalculator.md
@@ -415,23 +415,6 @@ Change the default macro factor
 |---|---|---|
 | _macroFactor | uint256 | The new default macro factor |
 
-### dailyPriceQuotesSum
-
-```solidity
-function dailyPriceQuotesSum() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### defaultMacroFactor
 
 ```solidity
@@ -717,7 +700,7 @@ function hydraChainContract() external view returns (contract IHydraChain)
 ### initialize
 
 ```solidity
-function initialize(address governance, address hydraChainAddr, uint256[310] prices) external nonpayable
+function initialize(address governance, address hydraChainAddr, address priceOracleAddr, uint256[310] prices) external nonpayable
 ```
 
 
@@ -730,6 +713,7 @@ function initialize(address governance, address hydraChainAddr, uint256[310] pri
 |---|---|---|
 | governance | address | undefined |
 | hydraChainAddr | address | undefined |
+| priceOracleAddr | address | undefined |
 | prices | uint256[310] | undefined |
 
 ### latestDailyPrice
@@ -766,10 +750,27 @@ function macroFactor() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### pricePerEpoch
+### priceOracleContract
 
 ```solidity
-function pricePerEpoch(uint256) external view returns (uint256)
+function priceOracleContract() external view returns (contract IPriceOracle)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPriceOracle | undefined |
+
+### pricePerDay
+
+```solidity
+function pricePerDay(uint256) external view returns (uint256)
 ```
 
 
@@ -787,39 +788,6 @@ function pricePerEpoch(uint256) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-
-### priceSumCounter
-
-```solidity
-function priceSumCounter() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-### quotePrice
-
-```solidity
-function quotePrice(uint256 _price) external nonpayable
-```
-
-Quotes the price for each epoch &amp; keeps the average price for each day
-
-*only the system can call this function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _price | uint256 | undefined |
 
 ### renounceRole
 
@@ -944,22 +912,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
-### updateTime
+### updatePrice
 
 ```solidity
-function updateTime() external view returns (uint256)
+function updatePrice(uint256 _price, uint256 _day) external nonpayable
 ```
 
+Updates the price for the last day
 
+*only the PriceOracle can call this function*
 
-
-
-
-#### Returns
+#### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _price | uint256 | undefined |
+| _day | uint256 | undefined |
 
 ### updatedPrices
 
@@ -1057,27 +1025,10 @@ event MacroFactorSet(uint256 macroFactor)
 |---|---|---|
 | macroFactor  | uint256 | undefined |
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -1088,7 +1039,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 ### RSIBonusSet
@@ -1198,17 +1149,6 @@ error InvalidMacroFactor()
 
 
 
-### InvalidPrice
-
-```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
 ### InvalidRSI
 
 ```solidity
@@ -1220,10 +1160,10 @@ error InvalidRSI()
 
 
 
-### PriceAlreadyQuoted
+### PriceAlreadySet
 
 ```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/APRCalculator/IAPRCalculator.md
+++ b/docs/APRCalculator/IAPRCalculator.md
@@ -261,22 +261,6 @@ Protects RSI bonus and Macro factor updates and set them to default values
 *only governance can call this function*
 
 
-### quotePrice
-
-```solidity
-function quotePrice(uint256 price) external nonpayable
-```
-
-Quotes the price for each epoch &amp; keeps the average price for each day
-
-*only the system can call this function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| price | uint256 | the amount to quote |
-
 ### setBase
 
 ```solidity
@@ -292,6 +276,23 @@ sets new base APR
 | Name | Type | Description |
 |---|---|---|
 | newBase | uint256 | new base APR |
+
+### updatePrice
+
+```solidity
+function updatePrice(uint256 price, uint256 day) external nonpayable
+```
+
+Updates the price for the last day
+
+*only the PriceOracle can call this function*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price | uint256 | the price to be updated |
+| day | uint256 | the day to be updated |
 
 
 
@@ -329,27 +330,10 @@ event MacroFactorSet(uint256 macroFactor)
 |---|---|---|
 | macroFactor  | uint256 | undefined |
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -360,7 +344,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 ### RSIBonusSet
@@ -416,17 +400,6 @@ error InvalidMacroFactor()
 
 
 
-### InvalidPrice
-
-```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
 ### InvalidRSI
 
 ```solidity
@@ -438,10 +411,10 @@ error InvalidRSI()
 
 
 
-### PriceAlreadyQuoted
+### PriceAlreadySet
 
 ```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/APRCalculator/modules/MacroFactor/MacroFactor.md
+++ b/docs/APRCalculator/modules/MacroFactor/MacroFactor.md
@@ -247,23 +247,6 @@ Change the default macro factor
 |---|---|---|
 | _macroFactor | uint256 | The new default macro factor |
 
-### dailyPriceQuotesSum
-
-```solidity
-function dailyPriceQuotesSum() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### defaultMacroFactor
 
 ```solidity
@@ -450,10 +433,27 @@ function macroFactor() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### pricePerEpoch
+### priceOracleContract
 
 ```solidity
-function pricePerEpoch(uint256) external view returns (uint256)
+function priceOracleContract() external view returns (contract IPriceOracle)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPriceOracle | undefined |
+
+### pricePerDay
+
+```solidity
+function pricePerDay(uint256) external view returns (uint256)
 ```
 
 
@@ -471,39 +471,6 @@ function pricePerEpoch(uint256) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-
-### priceSumCounter
-
-```solidity
-function priceSumCounter() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-### quotePrice
-
-```solidity
-function quotePrice(uint256 _price) external nonpayable
-```
-
-Quotes the price for each epoch &amp; keeps the average price for each day
-
-*only the system can call this function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _price | uint256 | undefined |
 
 ### renounceRole
 
@@ -595,22 +562,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
-### updateTime
+### updatePrice
 
 ```solidity
-function updateTime() external view returns (uint256)
+function updatePrice(uint256 _price, uint256 _day) external nonpayable
 ```
 
+Updates the price for the last day
 
+*only the PriceOracle can call this function*
 
-
-
-
-#### Returns
+#### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _price | uint256 | undefined |
+| _day | uint256 | undefined |
 
 ### updatedPrices
 
@@ -686,27 +653,10 @@ event MacroFactorSet(uint256 macroFactor)
 |---|---|---|
 | macroFactor  | uint256 | undefined |
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -717,7 +667,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 ### RoleAdminChanged
@@ -811,21 +761,10 @@ error InvalidMacroFactor()
 
 
 
-### InvalidPrice
+### PriceAlreadySet
 
 ```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
-### PriceAlreadyQuoted
-
-```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/APRCalculator/modules/Price/IPrice.md
+++ b/docs/APRCalculator/modules/Price/IPrice.md
@@ -32,47 +32,31 @@ Protects RSI bonus and Macro factor updates and set them to default values
 *only governance can call this function*
 
 
-### quotePrice
+### updatePrice
 
 ```solidity
-function quotePrice(uint256 price) external nonpayable
+function updatePrice(uint256 price, uint256 day) external nonpayable
 ```
 
-Quotes the price for each epoch &amp; keeps the average price for each day
+Updates the price for the last day
 
-*only the system can call this function*
+*only the PriceOracle can call this function*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| price | uint256 | the amount to quote |
+| price | uint256 | the price to be updated |
+| day | uint256 | the day to be updated |
 
 
 
 ## Events
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -83,7 +67,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 
@@ -112,21 +96,10 @@ error GuardAlreadyEnabled()
 
 
 
-### InvalidPrice
+### PriceAlreadySet
 
 ```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
-### PriceAlreadyQuoted
-
-```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/APRCalculator/modules/Price/Price.md
+++ b/docs/APRCalculator/modules/Price/Price.md
@@ -163,23 +163,6 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### dailyPriceQuotesSum
-
-```solidity
-function dailyPriceQuotesSum() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### disableGuard
 
 ```solidity
@@ -315,10 +298,27 @@ function latestDailyPrice() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### pricePerEpoch
+### priceOracleContract
 
 ```solidity
-function pricePerEpoch(uint256) external view returns (uint256)
+function priceOracleContract() external view returns (contract IPriceOracle)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPriceOracle | undefined |
+
+### pricePerDay
+
+```solidity
+function pricePerDay(uint256) external view returns (uint256)
 ```
 
 
@@ -336,39 +336,6 @@ function pricePerEpoch(uint256) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-
-### priceSumCounter
-
-```solidity
-function priceSumCounter() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-### quotePrice
-
-```solidity
-function quotePrice(uint256 _price) external nonpayable
-```
-
-Quotes the price for each epoch &amp; keeps the average price for each day
-
-*only the system can call this function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _price | uint256 | undefined |
 
 ### renounceRole
 
@@ -426,22 +393,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
-### updateTime
+### updatePrice
 
 ```solidity
-function updateTime() external view returns (uint256)
+function updatePrice(uint256 _price, uint256 _day) external nonpayable
 ```
 
+Updates the price for the last day
 
+*only the PriceOracle can call this function*
 
-
-
-
-#### Returns
+#### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _price | uint256 | undefined |
+| _day | uint256 | undefined |
 
 ### updatedPrices
 
@@ -485,27 +452,10 @@ event Initialized(uint8 version)
 |---|---|---|
 | version  | uint8 | undefined |
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -516,7 +466,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 ### RoleAdminChanged
@@ -599,21 +549,10 @@ error GuardAlreadyEnabled()
 
 
 
-### InvalidPrice
+### PriceAlreadySet
 
 ```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
-### PriceAlreadyQuoted
-
-```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/APRCalculator/modules/RSI/RSIndex.md
+++ b/docs/APRCalculator/modules/RSI/RSIndex.md
@@ -214,23 +214,6 @@ function averageLoss() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### dailyPriceQuotesSum
-
-```solidity
-function dailyPriceQuotesSum() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### disableGuard
 
 ```solidity
@@ -383,10 +366,27 @@ function latestDailyPrice() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### pricePerEpoch
+### priceOracleContract
 
 ```solidity
-function pricePerEpoch(uint256) external view returns (uint256)
+function priceOracleContract() external view returns (contract IPriceOracle)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPriceOracle | undefined |
+
+### pricePerDay
+
+```solidity
+function pricePerDay(uint256) external view returns (uint256)
 ```
 
 
@@ -404,39 +404,6 @@ function pricePerEpoch(uint256) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
-
-### priceSumCounter
-
-```solidity
-function priceSumCounter() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-### quotePrice
-
-```solidity
-function quotePrice(uint256 _price) external nonpayable
-```
-
-Quotes the price for each epoch &amp; keeps the average price for each day
-
-*only the system can call this function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _price | uint256 | undefined |
 
 ### renounceRole
 
@@ -511,22 +478,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
-### updateTime
+### updatePrice
 
 ```solidity
-function updateTime() external view returns (uint256)
+function updatePrice(uint256 _price, uint256 _day) external nonpayable
 ```
 
+Updates the price for the last day
 
+*only the PriceOracle can call this function*
 
-
-
-
-#### Returns
+#### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _price | uint256 | undefined |
+| _day | uint256 | undefined |
 
 ### updatedPrices
 
@@ -570,27 +537,10 @@ event Initialized(uint8 version)
 |---|---|---|
 | version  | uint8 | undefined |
 
-### PriceQuoted
-
-```solidity
-event PriceQuoted(uint256 indexed epochId, uint256 amount)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| epochId `indexed` | uint256 | undefined |
-| amount  | uint256 | undefined |
-
 ### PriceUpdated
 
 ```solidity
-event PriceUpdated(uint256 time, uint256 price)
+event PriceUpdated(uint256 day, uint256 price)
 ```
 
 
@@ -601,7 +551,7 @@ event PriceUpdated(uint256 time, uint256 price)
 
 | Name | Type | Description |
 |---|---|---|
-| time  | uint256 | undefined |
+| day  | uint256 | undefined |
 | price  | uint256 | undefined |
 
 ### RSIBonusSet
@@ -700,21 +650,10 @@ error GuardAlreadyEnabled()
 
 
 
-### InvalidPrice
+### PriceAlreadySet
 
 ```solidity
-error InvalidPrice()
-```
-
-
-
-
-
-
-### PriceAlreadyQuoted
-
-```solidity
-error PriceAlreadyQuoted()
+error PriceAlreadySet()
 ```
 
 

--- a/docs/PriceOracle/IPriceOracle.md
+++ b/docs/PriceOracle/IPriceOracle.md
@@ -10,10 +10,32 @@
 
 ## Methods
 
+### shouldVote
+
+```solidity
+function shouldVote(uint256 day) external view returns (bool)
+```
+
+Returns true if the validator can vote for the provided day
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| day | uint256 | The day to check |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | true if the validator can vote |
+
 ### vote
 
 ```solidity
-function vote(uint256 _price) external nonpayable
+function vote(uint256 price) external nonpayable
 ```
 
 Allows active validators to vote on the price
@@ -24,7 +46,7 @@ Allows active validators to vote on the price
 
 | Name | Type | Description |
 |---|---|---|
-| _price | uint256 | Price to vote |
+| price | uint256 | Price to vote |
 
 
 

--- a/docs/PriceOracle/IPriceOracle.md
+++ b/docs/PriceOracle/IPriceOracle.md
@@ -1,0 +1,12 @@
+# IPriceOracle
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/PriceOracle/IPriceOracle.md
+++ b/docs/PriceOracle/IPriceOracle.md
@@ -13,7 +13,7 @@
 ### shouldVote
 
 ```solidity
-function shouldVote(uint256 day) external view returns (bool)
+function shouldVote(uint256 day) external view returns (bool, string)
 ```
 
 Returns true if the validator can vote for the provided day
@@ -31,6 +31,7 @@ Returns true if the validator can vote for the provided day
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | true if the validator can vote |
+| _1 | string | error message if the validator cannot vote |
 
 ### vote
 
@@ -109,17 +110,6 @@ event PriceVoted(uint256 price, address validator, uint256 day)
 
 ## Errors
 
-### AlreadyVoted
-
-```solidity
-error AlreadyVoted()
-```
-
-
-
-
-
-
 ### InvalidPrice
 
 ```solidity
@@ -131,15 +121,20 @@ error InvalidPrice()
 
 
 
-### PriceAlreadySet
+### InvalidVote
 
 ```solidity
-error PriceAlreadySet()
+error InvalidVote(string message)
 ```
 
 
 
 
 
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| message | string | undefined |
 
 

--- a/docs/PriceOracle/IPriceOracle.md
+++ b/docs/PriceOracle/IPriceOracle.md
@@ -30,6 +30,24 @@ Allows active validators to vote on the price
 
 ## Events
 
+### PriceUpdateFailed
+
+```solidity
+event PriceUpdateFailed(uint256 price, uint256 day, bytes data)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| day  | uint256 | undefined |
+| data  | bytes | undefined |
+
 ### PriceUpdated
 
 ```solidity
@@ -73,6 +91,17 @@ event PriceVoted(uint256 price, address validator, uint256 day)
 
 ```solidity
 error AlreadyVoted()
+```
+
+
+
+
+
+
+### InvalidPrice
+
+```solidity
+error InvalidPrice()
 ```
 
 

--- a/docs/PriceOracle/IPriceOracle.md
+++ b/docs/PriceOracle/IPriceOracle.md
@@ -8,5 +8,87 @@
 
 
 
+## Methods
+
+### vote
+
+```solidity
+function vote(uint256 _price) external nonpayable
+```
+
+Allows active validators to vote on the price
+
+*it automatically updates the price if all conditions are met*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _price | uint256 | Price to vote |
+
+
+
+## Events
+
+### PriceUpdated
+
+```solidity
+event PriceUpdated(uint256 price, uint256 day)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| day  | uint256 | undefined |
+
+### PriceVoted
+
+```solidity
+event PriceVoted(uint256 price, address validator, uint256 day)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| validator  | address | undefined |
+| day  | uint256 | undefined |
+
+
+
+## Errors
+
+### AlreadyVoted
+
+```solidity
+error AlreadyVoted()
+```
+
+
+
+
+
+
+### PriceAlreadySet
+
+```solidity
+error PriceAlreadySet()
+```
+
+
+
+
+
 
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -129,28 +129,6 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
-### getTodayIfVoteAvailable
-
-```solidity
-function getTodayIfVoteAvailable(uint256 _price) external view returns (uint256 day)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _price | uint256 | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| day | uint256 | undefined |
-
 ### hydraChainContract
 
 ```solidity
@@ -231,6 +209,28 @@ function priceVotesForDay(uint256, uint256) external view returns (uint256 price
 | price | uint256 | undefined |
 | validator | address | undefined |
 
+### shouldVote
+
+```solidity
+function shouldVote(uint256 day) external view returns (bool)
+```
+
+Returns true if the validator can vote for the provided day
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| day | uint256 | The day to check |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | true if the validator can vote |
+
 ### validatorLastVotedDay
 
 ```solidity
@@ -256,7 +256,7 @@ function validatorLastVotedDay(address) external view returns (uint256)
 ### vote
 
 ```solidity
-function vote(uint256 _price) external nonpayable
+function vote(uint256 price) external nonpayable
 ```
 
 Allows active validators to vote on the price
@@ -267,7 +267,24 @@ Allows active validators to vote on the price
 
 | Name | Type | Description |
 |---|---|---|
-| _price | uint256 | Price to vote |
+| price | uint256 | Price to vote |
+
+### votingPowerPercentageNeeded
+
+```solidity
+function votingPowerPercentageNeeded() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -163,10 +163,32 @@ function initialize(address _hydraChainAddr, address _aprCalculatorAddr) externa
 | _hydraChainAddr | address | undefined |
 | _aprCalculatorAddr | address | undefined |
 
+### pricePerDay
+
+```solidity
+function pricePerDay(uint256) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### priceVotesForDay
 
 ```solidity
-function priceVotesForDay(uint256, uint256) external view returns (uint256)
+function priceVotesForDay(uint256, uint256) external view returns (uint256 price, address validator)
 ```
 
 
@@ -184,12 +206,13 @@ function priceVotesForDay(uint256, uint256) external view returns (uint256)
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| price | uint256 | undefined |
+| validator | address | undefined |
 
-### validatorVotedForDay
+### validatorLastVotedDay
 
 ```solidity
-function validatorVotedForDay(address) external view returns (uint256)
+function validatorLastVotedDay(address) external view returns (uint256)
 ```
 
 
@@ -214,15 +237,15 @@ function validatorVotedForDay(address) external view returns (uint256)
 function vote(uint256 _price) external nonpayable
 ```
 
+Allows active validators to vote on the price
 
-
-
+*it automatically updates the price if all conditions are met*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| _price | uint256 | undefined |
+| _price | uint256 | Price to vote |
 
 
 
@@ -244,9 +267,66 @@ event Initialized(uint8 version)
 |---|---|---|
 | version  | uint8 | undefined |
 
+### PriceUpdated
+
+```solidity
+event PriceUpdated(uint256 price, uint256 day)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| day  | uint256 | undefined |
+
+### PriceVoted
+
+```solidity
+event PriceVoted(uint256 price, address validator, uint256 day)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| validator  | address | undefined |
+| day  | uint256 | undefined |
+
 
 
 ## Errors
+
+### AlreadyVoted
+
+```solidity
+error AlreadyVoted()
+```
+
+
+
+
+
+
+### PriceAlreadySet
+
+```solidity
+error PriceAlreadySet()
+```
+
+
+
+
+
 
 ### Unauthorized
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -267,6 +267,24 @@ event Initialized(uint8 version)
 |---|---|---|
 | version  | uint8 | undefined |
 
+### PriceUpdateFailed
+
+```solidity
+event PriceUpdateFailed(uint256 price, uint256 day, bytes data)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| price  | uint256 | undefined |
+| day  | uint256 | undefined |
+| data  | bytes | undefined |
+
 ### PriceUpdated
 
 ```solidity
@@ -310,6 +328,17 @@ event PriceVoted(uint256 price, address validator, uint256 day)
 
 ```solidity
 error AlreadyVoted()
+```
+
+
+
+
+
+
+### InvalidPrice
+
+```solidity
+error InvalidPrice()
 ```
 
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -129,6 +129,28 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 |---|---|---|
 | _0 | contract IAPRCalculator | undefined |
 
+### getTodayIfVoteAvailable
+
+```solidity
+function getTodayIfVoteAvailable(uint256 _price) external view returns (uint256 day)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _price | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| day | uint256 | undefined |
+
 ### hydraChainContract
 
 ```solidity

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -112,6 +112,23 @@ function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### VOTING_POWER_PERCENTAGE_NEEDED
+
+```solidity
+function VOTING_POWER_PERCENTAGE_NEEDED() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### aprCalculatorContract
 
 ```solidity
@@ -269,23 +286,6 @@ Allows active validators to vote on the price
 | Name | Type | Description |
 |---|---|---|
 | price | uint256 | Price to vote |
-
-### votingPowerPercentageNeeded
-
-```solidity
-function votingPowerPercentageNeeded() external view returns (uint256)
-```
-
-
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
 
 
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -212,7 +212,7 @@ function priceVotesForDay(uint256, uint256) external view returns (uint256 price
 ### shouldVote
 
 ```solidity
-function shouldVote(uint256 day) external view returns (bool)
+function shouldVote(uint256 day) external view returns (bool, string)
 ```
 
 Returns true if the validator can vote for the provided day
@@ -230,6 +230,7 @@ Returns true if the validator can vote for the provided day
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | true if the validator can vote |
+| _1 | string | error message if the validator cannot vote |
 
 ### validatorLastVotedDay
 
@@ -363,17 +364,6 @@ event PriceVoted(uint256 price, address validator, uint256 day)
 
 ## Errors
 
-### AlreadyVoted
-
-```solidity
-error AlreadyVoted()
-```
-
-
-
-
-
-
 ### InvalidPrice
 
 ```solidity
@@ -385,16 +375,21 @@ error InvalidPrice()
 
 
 
-### PriceAlreadySet
+### InvalidVote
 
 ```solidity
-error PriceAlreadySet()
+error InvalidVote(string message)
 ```
 
 
 
 
 
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| message | string | undefined |
 
 ### Unauthorized
 

--- a/docs/PriceOracle/PriceOracle.md
+++ b/docs/PriceOracle/PriceOracle.md
@@ -1,0 +1,267 @@
+# PriceOracle
+
+
+
+> PriceOracle
+
+
+
+*This contract will be responsible for the price updates. Active validators will be able to vote and agree on the price.*
+
+## Methods
+
+### NATIVE_TOKEN_CONTRACT
+
+```solidity
+function NATIVE_TOKEN_CONTRACT() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### NATIVE_TRANSFER_PRECOMPILE
+
+```solidity
+function NATIVE_TRANSFER_PRECOMPILE() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### NATIVE_TRANSFER_PRECOMPILE_GAS
+
+```solidity
+function NATIVE_TRANSFER_PRECOMPILE_GAS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### SYSTEM
+
+```solidity
+function SYSTEM() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### VALIDATOR_PKCHECK_PRECOMPILE
+
+```solidity
+function VALIDATOR_PKCHECK_PRECOMPILE() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### VALIDATOR_PKCHECK_PRECOMPILE_GAS
+
+```solidity
+function VALIDATOR_PKCHECK_PRECOMPILE_GAS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### aprCalculatorContract
+
+```solidity
+function aprCalculatorContract() external view returns (contract IAPRCalculator)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IAPRCalculator | undefined |
+
+### hydraChainContract
+
+```solidity
+function hydraChainContract() external view returns (contract IHydraChain)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IHydraChain | undefined |
+
+### initialize
+
+```solidity
+function initialize(address _hydraChainAddr, address _aprCalculatorAddr) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _hydraChainAddr | address | undefined |
+| _aprCalculatorAddr | address | undefined |
+
+### priceVotesForDay
+
+```solidity
+function priceVotesForDay(uint256, uint256) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+| _1 | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### validatorVotedForDay
+
+```solidity
+function validatorVotedForDay(address) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### vote
+
+```solidity
+function vote(uint256 _price) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _price | uint256 | undefined |
+
+
+
+## Events
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
+
+
+
+## Errors
+
+### Unauthorized
+
+```solidity
+error Unauthorized(string only)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| only | string | undefined |
+
+

--- a/docs/PriceOracle/PriceOracleConnector.md
+++ b/docs/PriceOracle/PriceOracleConnector.md
@@ -1,0 +1,51 @@
+# PriceOracleConnector
+
+
+
+
+
+
+
+
+
+## Methods
+
+### priceOracleContract
+
+```solidity
+function priceOracleContract() external view returns (contract IPriceOracle)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPriceOracle | undefined |
+
+
+
+## Events
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
+
+
+

--- a/test/APRCalculator/MacroFactor.test.ts
+++ b/test/APRCalculator/MacroFactor.test.ts
@@ -1,15 +1,7 @@
 /* eslint-disable node/no-extraneous-import */
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
-import {
-  DAY,
-  ERRORS,
-  INITIAL_DEFAULT_MACRO_FACTOR,
-  INITIAL_PRICE,
-  MAX_MACRO_FACTOR,
-  MIN_MACRO_FACTOR,
-} from "../constants";
-import { commitEpoch } from "../helper";
+import { ERRORS, INITIAL_DEFAULT_MACRO_FACTOR, MAX_MACRO_FACTOR, MIN_MACRO_FACTOR } from "../constants";
 
 export function RunMacroFactorTests(): void {
   it("should get macro factor", async function () {
@@ -22,40 +14,32 @@ export function RunMacroFactorTests(): void {
 
   describe("Set Macro Factor", function () {
     it("should emit MacroFactorSet event on price update", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
+      const { aprCalculator, priceOracle, priceToVote, validatorToVote } = await loadFixture(
+        this.fixtures.votedValidatorsStateFixture
       );
-      // need to quote price before updating it
-      await aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE / 2);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY);
 
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE * 2)).to.emit(
-        aprCalculator,
-        "MacroFactorSet"
-      );
+      await expect(priceOracle.connect(validatorToVote).vote(priceToVote)).to.emit(aprCalculator, "MacroFactorSet");
     });
 
     it("should update properly change SMA sum on price update", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
+      const { aprCalculator, priceToVote, priceOracle, validatorToVote } = await loadFixture(
+        this.fixtures.votedValidatorsStateFixture
       );
-
-      await aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE / 2);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY);
 
       const smaFastSum = await aprCalculator.smaFastSum();
       const smaSlowSum = await aprCalculator.smaSlowSum();
-      // need to quote price again to update the price we already quoted above
-      await aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE * 3);
+      await priceOracle.connect(validatorToVote).vote(priceToVote);
 
-      expect(await aprCalculator.smaFastSum(), "SMA Fast Sum").to.below(smaFastSum);
-      expect(await aprCalculator.smaSlowSum(), "SMA Slow Sum").to.below(smaSlowSum);
+      expect(await aprCalculator.smaFastSum(), "SMA Fast Sum").to.above(smaFastSum);
+      expect(await aprCalculator.smaSlowSum(), "SMA Slow Sum").to.above(smaSlowSum);
     });
   });
 
   describe("Guard Macro Factor", function () {
     it("should successfully guard macro factor & disable updates", async function () {
-      const { aprCalculator } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
+      const { aprCalculator, priceOracle, priceToVote, validatorToVote } = await loadFixture(
+        this.fixtures.votedValidatorsStateFixture
+      );
       const oldSMASlowSum = await aprCalculator.smaSlowSum();
       const oldSMAFastSum = await aprCalculator.smaFastSum();
 
@@ -63,10 +47,7 @@ export function RunMacroFactorTests(): void {
         .to.emit(aprCalculator, "MacroFactorSet")
         .withArgs(INITIAL_DEFAULT_MACRO_FACTOR);
 
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE / 2)).to.not.emit(
-        aprCalculator,
-        "MacroFactorSet"
-      );
+      await expect(priceOracle.connect(validatorToVote).vote(priceToVote)).to.not.emit(aprCalculator, "MacroFactorSet");
       const currentMacroFactor = await aprCalculator.getMacroFactor();
       expect(currentMacroFactor).to.equal(INITIAL_DEFAULT_MACRO_FACTOR);
       expect(await aprCalculator.disabledBonusesUpdates()).to.be.true;
@@ -75,13 +56,9 @@ export function RunMacroFactorTests(): void {
     });
 
     it("should disable guard and enable macro factor updates", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
+      const { aprCalculator, priceOracle, priceToVote, validatorToVote } = await loadFixture(
+        this.fixtures.votedValidatorsStateFixture
       );
-
-      // need to quote price before updating it
-      await aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE / 2);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY);
 
       await aprCalculator.connect(this.signers.governance).guardBonuses();
       expect(await aprCalculator.disabledBonusesUpdates()).to.be.true;
@@ -90,10 +67,7 @@ export function RunMacroFactorTests(): void {
       await aprCalculator.connect(this.signers.governance).disableGuard();
       expect(await aprCalculator.disabledBonusesUpdates()).to.be.false;
 
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(INITIAL_PRICE / 2)).to.emit(
-        aprCalculator,
-        "MacroFactorSet"
-      );
+      await expect(priceOracle.connect(validatorToVote).vote(priceToVote)).to.emit(aprCalculator, "MacroFactorSet");
     });
   });
 

--- a/test/APRCalculator/Price.test.ts
+++ b/test/APRCalculator/Price.test.ts
@@ -1,165 +1,31 @@
 /* eslint-disable node/no-extraneous-import */
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
-import { DAY, ERRORS, INITIAL_PRICE, WEEK } from "../constants";
-import { ethers } from "hardhat";
-import { commitEpoch } from "../helper";
+import { ERRORS } from "../constants";
+import { getCurrentDay } from "../helper";
 
 export function RunPriceTests(): void {
-  describe("quotePrice", function () {
-    it("should revert quotePrice if not called by system", async function () {
-      const { aprCalculator } = await loadFixture(this.fixtures.presetHydraChainStateFixture);
-
-      await expect(aprCalculator.quotePrice(100))
-        .to.be.revertedWithCustomError(aprCalculator, ERRORS.unauthorized.name)
-        .withArgs(ERRORS.unauthorized.systemCallArg);
-    });
-
-    it("should revert quotePrice if price is 0", async function () {
-      const { aprCalculator } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
-
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(0)).to.be.revertedWithCustomError(
-        aprCalculator,
-        "InvalidPrice"
-      );
-    });
-
-    it("should revert quotePrice if we already updated the price for the current epoch", async function () {
-      const { aprCalculator } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
-
-      await aprCalculator.connect(this.signers.system).quotePrice(100);
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(111)).to.be.revertedWithCustomError(
-        aprCalculator,
-        "PriceAlreadyQuoted"
-      );
-    });
-
-    it("should successfully quotePrice", async function () {
-      const { aprCalculator, hydraChain } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
-      const currentEpoch = await hydraChain.currentEpochId();
-
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(132))
-        .to.emit(aprCalculator, "PriceQuoted")
-        .withArgs(currentEpoch, 132);
-      expect(await aprCalculator.dailyPriceQuotesSum()).to.equal(132);
-      expect(await aprCalculator.priceSumCounter()).to.equal(1);
-      expect(await aprCalculator.pricePerEpoch(currentEpoch)).to.equal(132);
-    });
-  });
-
   describe("updatePrice", function () {
-    it("should not update time if no price was quoted", async function () {
+    it("should revert if not called by Price Oracle", async function () {
       const { aprCalculator } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
 
-      // increase time so it pass update time
-      await ethers.provider.send("evm_increaseTime", [10000]);
-      await ethers.provider.send("evm_mine", []);
-
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(100)).to.not.emit(
-        aprCalculator,
-        "PriceUpdated"
-      );
-      expect(await aprCalculator.latestDailyPrice()).to.equal(INITIAL_PRICE);
+      await expect(aprCalculator.connect(this.signers.system).updatePrice(111, 1))
+        .to.be.revertedWithCustomError(aprCalculator, ERRORS.unauthorized.name)
+        .withArgs(ERRORS.unauthorized.priceOracleArg);
     });
 
-    it("should make sure update time is always 00:00:00 for the next day", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
+    it("should update price correctly", async function () {
+      const { aprCalculator, priceOracle, priceToVote, validatorToVote } = await loadFixture(
+        this.fixtures.votedValidatorsStateFixture
       );
-      await aprCalculator.connect(this.signers.system).quotePrice(100);
-      // increase time so it pass update by more than a week
-      await ethers.provider.send("evm_increaseTime", [1000000]);
-      await ethers.provider.send("evm_mine", []);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize);
+      const currentDay = await getCurrentDay();
 
-      const updateTimeBefore = await aprCalculator.updateTime();
-      expect(updateTimeBefore.add(WEEK)).to.be.below((await ethers.provider.getBlock("latest")).timestamp);
-
-      await aprCalculator.connect(this.signers.system).quotePrice(100);
-      const updateTimeAfter = await aprCalculator.updateTime();
-      expect(updateTimeAfter).to.be.above((await ethers.provider.getBlock("latest")).timestamp);
-      expect(updateTimeAfter.mod(DAY)).to.equal(0);
-    });
-
-    it("should update price after a day", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
-      );
-
-      await aprCalculator.connect(this.signers.system).quotePrice(111);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize);
-
-      expect(await aprCalculator.dailyPriceQuotesSum(), "dailyPriceQuotesSum").to.equal(111);
-      expect(await aprCalculator.priceSumCounter(), "priceSumCounter").to.equal(1);
-
-      // Get timestamp & update time
-      const block = await ethers.provider.getBlock("latest");
-      const currentTimestamp = block.timestamp;
-      const updateTime = await aprCalculator.updateTime();
-      const dayBigNum = ethers.BigNumber.from(DAY);
-
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(222))
+      await expect(priceOracle.connect(validatorToVote).vote(priceToVote))
         .to.emit(aprCalculator, "PriceUpdated")
-        .withArgs(currentTimestamp + 1, 111);
+        .withArgs(currentDay, priceToVote);
 
-      expect(await aprCalculator.latestDailyPrice(), "latestDailyPrice").to.equal(111);
-      expect(await aprCalculator.dailyPriceQuotesSum()).to.equal(222);
-      expect(await aprCalculator.priceSumCounter()).to.equal(1);
-      expect(await aprCalculator.updateTime()).to.equal(updateTime.add(dayBigNum));
-    });
-
-    it("should calculate price correctly", async function () {
-      const { aprCalculator, systemHydraChain, hydraStaking } = await loadFixture(
-        this.fixtures.initializedHydraChainStateFixture
-      );
-
-      // Handle time to be at the start of the day
-      const currBlock = await ethers.provider.getBlock("latest");
-      const time = currBlock.timestamp;
-      const nextUpdateTime = time + (86400 - (time % 86400));
-      const neededTime = nextUpdateTime - time;
-
-      await ethers.provider.send("evm_increaseTime", [neededTime]);
-      await ethers.provider.send("evm_mine", []);
-
-      const price1 = 132;
-      const price2 = 231;
-      const price3 = 174;
-      const price4 = 189;
-
-      // we need to quote price here, cuz the counter is 0 and we still have not updated the price
-      await aprCalculator.connect(this.signers.system).quotePrice(1);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, 1);
-
-      await aprCalculator.connect(this.signers.system).quotePrice(price1);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY / 3);
-
-      await aprCalculator.connect(this.signers.system).quotePrice(price2);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY / 3);
-
-      await aprCalculator.connect(this.signers.system).quotePrice(price3);
-      await commitEpoch(systemHydraChain, hydraStaking, [this.signers.validators[1]], this.epochSize, DAY / 3);
-
-      expect(await aprCalculator.dailyPriceQuotesSum(), "dailyPriceQuotesSum before").to.equal(
-        price1 + price2 + price3
-      );
-      expect(await aprCalculator.priceSumCounter(), "priceSumCounter").to.equal(3);
-
-      // Get timestamp & update time
-      const block = await ethers.provider.getBlock("latest");
-      const currentTimestamp = block.timestamp;
-      const updateTime = await aprCalculator.updateTime();
-      const dayBigNum = ethers.BigNumber.from(DAY);
-      const updatedPrice = (price1 + price2 + price3) / 3;
-
-      await expect(aprCalculator.connect(this.signers.system).quotePrice(price4))
-        .to.emit(aprCalculator, "PriceUpdated")
-        .withArgs(currentTimestamp + 1, updatedPrice);
-
-      expect(await aprCalculator.latestDailyPrice(), "latestDailyPrice").to.equal(updatedPrice);
-      expect(await aprCalculator.dailyPriceQuotesSum(), "dailyPriceQuotesSum after").to.equal(price4);
-      expect(await aprCalculator.priceSumCounter(), "priceSumCounter after").to.equal(1);
-      expect(await aprCalculator.updateTime()).to.equal(updateTime.add(dayBigNum));
+      expect(await aprCalculator.latestDailyPrice(), "latestDailyPrice").to.equal(priceToVote);
+      expect(await aprCalculator.pricePerDay(currentDay), "pricePerDay").to.equal(priceToVote);
     });
   });
 

--- a/test/HydraChain/ValidatrosData.test.ts
+++ b/test/HydraChain/ValidatrosData.test.ts
@@ -106,4 +106,25 @@ export function RunValidatorsDataTests(): void {
 
     expect(await hydraChain.getTotalVotingPower()).to.deep.equal(20);
   });
+
+  it("should get the validator power", async function () {
+    const { hydraChain } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
+
+    const validatorsData = [{ validator: this.signers.validators[1].address, votingPower: 15 }];
+    await hydraChain.connect(this.signers.system).syncValidatorsData(validatorsData);
+
+    expect(await hydraChain.getValidatorPower(this.signers.validators[1].address)).to.deep.equal(15);
+  });
+
+  it("should get the total voting power", async function () {
+    const { hydraChain } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
+
+    const validatorsData = [
+      { validator: this.signers.validators[1].address, votingPower: 12 },
+      { validator: this.signers.validators[2].address, votingPower: 8 },
+    ];
+    await hydraChain.connect(this.signers.system).syncValidatorsData(validatorsData);
+
+    expect(await hydraChain.getTotalVotingPower()).to.deep.equal(20);
+  });
 }

--- a/test/HydraStaking/Staking.test.ts
+++ b/test/HydraStaking/Staking.test.ts
@@ -7,11 +7,12 @@ import { ERRORS } from "../constants";
 
 export function RunStakingTests(): void {
   describe("Stake", function () {
-    it("should allow only registered & active validators to stake", async function () {
-      // * Only the first three validators are being registered
-      const { hydraStaking } = await loadFixture(this.fixtures.registeredValidatorsStateFixture);
+    it("should allow only registered or active validators to stake", async function () {
+      const { hydraStaking, hydraChain } = await loadFixture(this.fixtures.registeredValidatorsStateFixture);
 
-      await expect(hydraStaking.connect(this.signers.validators[3]).stake({ value: this.minStake }))
+      const newValidator = this.signers.accounts[10];
+      await hydraChain.connect(this.signers.governance).addToWhitelist([newValidator.address]);
+      await expect(hydraStaking.connect(newValidator).stake({ value: this.minStake }))
         .to.be.revertedWithCustomError(hydraStaking, ERRORS.unauthorized.name)
         .withArgs(ERRORS.mustBeRegistered);
     });

--- a/test/PriceOracle/PriceOracle.test.ts
+++ b/test/PriceOracle/PriceOracle.test.ts
@@ -50,7 +50,7 @@ export function RunPriceOracleTests(): void {
 
       await expect(priceOracle.connect(this.signers.validators[2]).vote(21))
         .to.be.revertedWithCustomError(priceOracle, "InvalidVote")
-        .withArgs("VALIDATOR_WITHOUT_POWER");
+        .withArgs("NOT_VALIDATOR");
     });
 
     it("should revert vote with 0 price", async function () {
@@ -150,7 +150,7 @@ export function RunPriceOracleTests(): void {
       const price1 = 222222221;
       const price2 = 222222222;
       const price3 = 222222228;
-      const expectedPrice = Math.floor(((price1 + price2) / 2 + price3) / 2);
+      const expectedPrice = Math.floor((price1 + price2 + price3) / 3);
 
       await priceOracle.connect(this.signers.validators[0]).vote(price1);
       await priceOracle.connect(this.signers.validators[1]).vote(price2);

--- a/test/PriceOracle/PriceOracle.test.ts
+++ b/test/PriceOracle/PriceOracle.test.ts
@@ -1,0 +1,34 @@
+import { ethers } from "hardhat";
+/* eslint-disable node/no-extraneous-import */
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+
+import { ERRORS } from "../constants";
+
+export function RunPriceOracleTests(): void {
+  describe.only("Initialization", function () {
+    it("should validate default values when PriceOracle is deployed", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.presetHydraChainStateFixture);
+
+      expect(await priceOracle.hydraChainContract()).to.equal(ethers.constants.AddressZero);
+      expect(await priceOracle.aprCalculatorContract()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("should revert when initialize without system call", async function () {
+      const { priceOracle, hydraChain, aprCalculator } = await loadFixture(this.fixtures.presetHydraChainStateFixture);
+
+      await expect(priceOracle.initialize(hydraChain.address, aprCalculator.address))
+        .to.be.revertedWithCustomError(priceOracle, ERRORS.unauthorized.name)
+        .withArgs(ERRORS.unauthorized.systemCallArg);
+    });
+
+    it("should initialize successfully", async function () {
+      const { priceOracle, hydraChain, aprCalculator } = await loadFixture(
+        this.fixtures.initializedHydraChainStateFixture
+      );
+
+      expect(await priceOracle.hydraChainContract()).to.equal(hydraChain.address);
+      expect(await priceOracle.aprCalculatorContract()).to.equal(aprCalculator.address);
+    });
+  });
+}

--- a/test/PriceOracle/PriceOracle.test.ts
+++ b/test/PriceOracle/PriceOracle.test.ts
@@ -48,8 +48,8 @@ export function RunPriceOracleTests(): void {
       const { priceOracle } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
 
       await expect(priceOracle.connect(this.signers.validators[2]).vote(21))
-        .to.be.revertedWithCustomError(priceOracle, ERRORS.unauthorized.name)
-        .withArgs(ERRORS.unauthorized.inactiveStakerArg);
+        .to.be.revertedWithCustomError(priceOracle, "InvalidVote")
+        .withArgs("INACTIVE_STAKER");
     });
 
     it("should revert vote with 0 price", async function () {
@@ -80,10 +80,9 @@ export function RunPriceOracleTests(): void {
 
       await priceOracle.connect(this.signers.validators[0]).vote(21);
 
-      await expect(priceOracle.connect(this.signers.validators[0]).vote(25)).to.be.revertedWithCustomError(
-        priceOracle,
-        "AlreadyVoted"
-      );
+      await expect(priceOracle.connect(this.signers.validators[0]).vote(25))
+        .to.be.revertedWithCustomError(priceOracle, "InvalidVote")
+        .withArgs("ALREADY_VOTED");
     });
 
     it("should revert vote when price for the day is updated", async function () {
@@ -94,10 +93,9 @@ export function RunPriceOracleTests(): void {
       await priceOracle.connect(this.signers.validators[2]).vote(21);
       await priceOracle.connect(this.signers.validators[3]).vote(21);
 
-      await expect(priceOracle.connect(this.signers.validators[1]).vote(25)).to.be.revertedWithCustomError(
-        priceOracle,
-        "PriceAlreadySet"
-      );
+      await expect(priceOracle.connect(this.signers.validators[1]).vote(25))
+        .to.be.revertedWithCustomError(priceOracle, "InvalidVote")
+        .withArgs("PRICE_ALREADY_SET");
     });
   });
 

--- a/test/PriceOracle/PriceOracle.test.ts
+++ b/test/PriceOracle/PriceOracle.test.ts
@@ -4,9 +4,10 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 
 import { ERRORS } from "../constants";
+import { getCurrentDay } from "../helper";
 
 export function RunPriceOracleTests(): void {
-  describe.only("Initialization", function () {
+  describe("Initialization", function () {
     it("should validate default values when PriceOracle is deployed", async function () {
       const { priceOracle } = await loadFixture(this.fixtures.presetHydraChainStateFixture);
 
@@ -29,6 +30,150 @@ export function RunPriceOracleTests(): void {
 
       expect(await priceOracle.hydraChainContract()).to.equal(hydraChain.address);
       expect(await priceOracle.aprCalculatorContract()).to.equal(aprCalculator.address);
+    });
+
+    it("should revert re-initializing attempt", async function () {
+      const { priceOracle, hydraChain, aprCalculator } = await loadFixture(
+        this.fixtures.initializedHydraChainStateFixture
+      );
+
+      await expect(priceOracle.initialize(hydraChain.address, aprCalculator.address)).to.be.revertedWith(
+        ERRORS.initialized
+      );
+    });
+  });
+
+  describe("Voting for price", function () {
+    it("should revert when vote with non-active validator", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.initializedHydraChainStateFixture);
+
+      await expect(priceOracle.connect(this.signers.validators[2]).vote(21))
+        .to.be.revertedWithCustomError(priceOracle, ERRORS.unauthorized.name)
+        .withArgs(ERRORS.unauthorized.inactiveStakerArg);
+    });
+
+    it("should revert vote with 0 price", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
+
+      await expect(priceOracle.connect(this.signers.validators[0]).vote(0)).to.be.revertedWithCustomError(
+        priceOracle,
+        "InvalidPrice"
+      );
+    });
+
+    it("should vote successfully", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
+      const currentDay = await getCurrentDay();
+
+      await expect(priceOracle.connect(this.signers.validators[0]).vote(21))
+        .to.emit(priceOracle, "PriceVoted")
+        .withArgs(21, this.signers.validators[0].address, currentDay);
+      expect(await priceOracle.validatorLastVotedDay(this.signers.validators[0].address)).to.equal(currentDay);
+
+      const pricesForDay = await priceOracle.priceVotesForDay(currentDay, [0]);
+      expect(pricesForDay.price).to.equal(21);
+      expect(pricesForDay.validator).to.equal(this.signers.validators[0].address);
+    });
+
+    it("should revert double voting in the same day", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.stakedValidatorsStateFixture);
+
+      await priceOracle.connect(this.signers.validators[0]).vote(21);
+
+      await expect(priceOracle.connect(this.signers.validators[0]).vote(25)).to.be.revertedWithCustomError(
+        priceOracle,
+        "AlreadyVoted"
+      );
+    });
+
+    it("should revert vote when price for the day is updated", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+
+      await priceOracle.connect(this.signers.validators[0]).vote(21);
+      await priceOracle.connect(this.signers.validators[1]).vote(21);
+      await priceOracle.connect(this.signers.validators[2]).vote(21);
+      await priceOracle.connect(this.signers.validators[3]).vote(21);
+
+      await expect(priceOracle.connect(this.signers.validators[1]).vote(25)).to.be.revertedWithCustomError(
+        priceOracle,
+        "PriceAlreadySet"
+      );
+    });
+  });
+
+  describe("Price update", function () {
+    it("should not update price if votes are less than 4, even if they have enough power", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+
+      await priceOracle.connect(this.signers.validators[0]).vote(21);
+      await priceOracle.connect(this.signers.validators[1]).vote(21);
+      await expect(priceOracle.connect(this.signers.validators[2]).vote(21)).to.not.emit(priceOracle, "PriceUpdated");
+    });
+
+    it("should not update price, if there is is not enough power for a price (rounding to 1%)", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+
+      await priceOracle.connect(this.signers.validators[0]).vote(10);
+      await priceOracle.connect(this.signers.validators[1]).vote(14);
+      await priceOracle.connect(this.signers.validators[2]).vote(18);
+      await expect(priceOracle.connect(this.signers.validators[3]).vote(24)).to.not.emit(priceOracle, "PriceUpdated");
+    });
+
+    it("should update price successfully", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+      const currentDay = await getCurrentDay();
+
+      await priceOracle.connect(this.signers.validators[0]).vote(221);
+      await priceOracle.connect(this.signers.validators[1]).vote(221);
+      await priceOracle.connect(this.signers.validators[2]).vote(221);
+      await expect(priceOracle.connect(this.signers.validators[3]).vote(221))
+        .to.emit(priceOracle, "PriceUpdated")
+        .withArgs(221, currentDay);
+    });
+
+    it("should update price if 61% power agrees on price (rounding to 1%), even if other validators voted for different price", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+      const currentDay = await getCurrentDay();
+
+      await priceOracle.connect(this.signers.validators[0]).vote(142);
+      await priceOracle.connect(this.signers.validators[1]).vote(56);
+      await priceOracle.connect(this.signers.validators[2]).vote(56);
+      await expect(priceOracle.connect(this.signers.validators[3]).vote(56))
+        .to.emit(priceOracle, "PriceUpdated")
+        .withArgs(56, currentDay);
+    });
+
+    it("should update the average price of votes (if they are all around the same value to 1%)", async function () {
+      const { priceOracle } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+      const currentDay = await getCurrentDay();
+
+      const price1 = 222222221;
+      const price2 = 222222222;
+      const price3 = 222222228;
+      const expectedPrice = Math.floor((price1 + price2 + price3) / 3);
+
+      await priceOracle.connect(this.signers.validators[0]).vote(price1);
+      await priceOracle.connect(this.signers.validators[1]).vote(price2);
+      await priceOracle.connect(this.signers.validators[2]).vote(price3);
+      // the last vote does not matter, since others already have enough power to update the price
+      await expect(priceOracle.connect(this.signers.validators[3]).vote(1))
+        .to.emit(priceOracle, "PriceUpdated")
+        .withArgs(expectedPrice, currentDay);
+    });
+
+    it("should not revert call if APRCalculator priceUpdate fails, it emit event for fail", async function () {
+      const { hydraChain } = await loadFixture(this.fixtures.validatorsDataFixtureStateFixture);
+
+      const newPriceOracleContract = await (await ethers.getContractFactory("PriceOracle")).deploy();
+      await newPriceOracleContract.connect(this.signers.system).initialize(hydraChain.address, hydraChain.address);
+
+      await newPriceOracleContract.connect(this.signers.validators[0]).vote(142);
+      await newPriceOracleContract.connect(this.signers.validators[1]).vote(56);
+      await newPriceOracleContract.connect(this.signers.validators[2]).vote(56);
+      await expect(newPriceOracleContract.connect(this.signers.validators[3]).vote(56)).to.emit(
+        newPriceOracleContract,
+        "PriceUpdateFailed"
+      );
     });
   });
 }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -51,6 +51,7 @@ export const ERRORS = {
     onlyHydraStakingArg: "ONLY_HYDRA_STAKING",
     onlyHydraDelegationArg: "ONLY_HYDRA_DELEGATION",
     inactiveStakerArg: "INACTIVE_STAKER",
+    priceOracleArg: "ONLY_PRICE_ORACLE",
   },
   inactiveValidator: "INACTIVE_VALIDATOR",
   invalidValidator: "INVALID_VALIDATOR",

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -487,18 +487,16 @@ async function validatorsDataFixtureStateFixtureFunction(this: Mocha.Context) {
   const { hydraChain, systemHydraChain, bls, hydraStaking, hydraDelegation, liquidToken, aprCalculator, priceOracle } =
     await loadFixture(this.fixtures.registeredValidatorsStateFixture);
 
-  // set the rsi to the minimum value
-  await aprCalculator.connect(this.signers.governance).setRSI(MIN_RSI_BONUS);
   await hydraStaking.connect(this.signers.validators[0]).stake({ value: this.minStake.mul(2) });
   await hydraStaking.connect(this.signers.validators[1]).stake({ value: this.minStake.mul(2) });
   await hydraStaking.connect(this.signers.validators[2]).stake({ value: this.minStake.mul(2) });
   await hydraStaking.connect(this.signers.validators[3]).stake({ value: this.minStake.mul(2) });
 
   const validatorsData = [
-    { validator: this.signers.validators[0].address, votingPower: 12 },
-    { validator: this.signers.validators[1].address, votingPower: 8 },
-    { validator: this.signers.validators[2].address, votingPower: 6 },
-    { validator: this.signers.validators[3].address, votingPower: 14 },
+    { validator: this.signers.validators[0].address, votingPower: 24 },
+    { validator: this.signers.validators[1].address, votingPower: 18 },
+    { validator: this.signers.validators[2].address, votingPower: 22 },
+    { validator: this.signers.validators[3].address, votingPower: 26 },
   ];
   await hydraChain.connect(this.signers.system).syncValidatorsData(validatorsData);
 
@@ -586,6 +584,7 @@ async function stakedValidatorsStateFixtureFunction(this: Mocha.Context) {
     aprCalculator,
     liquidToken,
     vestingManagerFactory,
+    priceOracle,
     rewardWallet,
   } = await loadFixture(this.fixtures.registeredValidatorsStateFixture);
 
@@ -602,6 +601,7 @@ async function stakedValidatorsStateFixtureFunction(this: Mocha.Context) {
     liquidToken,
     aprCalculator,
     vestingManagerFactory,
+    priceOracle,
     rewardWallet,
   };
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -382,6 +382,11 @@ export async function calculateRSIBonus(averageGain: number, averageLoss: number
   }
 }
 
+export async function getCurrentDay() {
+  const block = await hre.ethers.provider.getBlock("latest");
+  return Math.floor(block.timestamp / DAY);
+}
+
 export async function applyCustomReward(
   hydraDelegation: HydraDelegation,
   validator: string,

--- a/test/index.ts
+++ b/test/index.ts
@@ -68,7 +68,7 @@ describe("Hydra Contracts", function () {
     RunVestingManagerTests();
   });
 
-  describe.only("PriceOracle", function () {
+  describe("PriceOracle", function () {
     RunPriceOracleTests();
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -12,6 +12,7 @@ import { RunHydraDelegationTests } from "./HydraDelegation/HydraDelegation.test"
 import { RunVestingManagerTests } from "./VestingManager/VestingManager.test";
 import { RunRewardWalletTests } from "./RewardWallet/RewardWallet.test";
 import { RunWithdrawalTests } from "./common/Withdrawal.test";
+import { RunPriceOracleTests } from "./PriceOracle/PriceOracle.test";
 
 describe("Hydra Contracts", function () {
   before(async function () {
@@ -65,6 +66,10 @@ describe("Hydra Contracts", function () {
 
   describe("VestingManager", function () {
     RunVestingManagerTests();
+  });
+
+  describe("PriceOracle", function () {
+    RunPriceOracleTests();
   });
 
   describe("RewardWallet", function () {

--- a/test/index.ts
+++ b/test/index.ts
@@ -68,7 +68,7 @@ describe("Hydra Contracts", function () {
     RunVestingManagerTests();
   });
 
-  describe("PriceOracle", function () {
+  describe.only("PriceOracle", function () {
     RunPriceOracleTests();
   });
 

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -103,9 +103,7 @@ export interface Fixtures {
       hydraStaking: HydraStaking;
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
-      vestingManagerFactory: VestingManagerFactory;
-      rewardWallet: RewardWallet;
-      DAOIncentiveVault: HydraVault;
+      priceOracle: PriceOracle;
     }>;
   };
   whitelistedValidatorsStateFixture: {
@@ -136,7 +134,7 @@ export interface Fixtures {
       rewardWallet: RewardWallet;
     }>;
   };
-  validatorsDataFixtureStateFixture: {
+  validatorsDataStateFixture: {
     (): Promise<{
       hydraChain: HydraChain;
       systemHydraChain: HydraChain;
@@ -146,6 +144,20 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       priceOracle: PriceOracle;
+    }>;
+  };
+  votedValidatorsStateFixture: {
+    (): Promise<{
+      hydraChain: HydraChain;
+      systemHydraChain: HydraChain;
+      bls: BLS;
+      hydraDelegation: HydraDelegation;
+      hydraStaking: HydraStaking;
+      liquidToken: LiquidityToken;
+      aprCalculator: APRCalculator;
+      priceOracle: PriceOracle;
+      priceToVote: number;
+      validatorToVote: SignerWithAddress;
     }>;
   };
   stakedValidatorsStateFixture: {

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -13,6 +13,7 @@ import {
   VestingManager,
   RewardWallet,
   HydraVault,
+  PriceOracle,
 } from "../typechain-types";
 
 export interface Signers {
@@ -36,6 +37,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
       DAOIncentiveVault: HydraVault;
     }>;
@@ -50,6 +52,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
       DAOIncentiveVault: HydraVault;
       validatorInit: {
@@ -71,6 +74,7 @@ export interface Fixtures {
       aprCalculator: APRCalculator;
       commitEpochTx: ContractTransaction;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
       DAOIncentiveVault: HydraVault;
     }>;
@@ -114,6 +118,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
     }>;
   };
@@ -127,7 +132,20 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
+    }>;
+  };
+  validatorsDataFixtureStateFixture: {
+    (): Promise<{
+      hydraChain: HydraChain;
+      systemHydraChain: HydraChain;
+      bls: BLS;
+      hydraDelegation: HydraDelegation;
+      hydraStaking: HydraStaking;
+      liquidToken: LiquidityToken;
+      aprCalculator: APRCalculator;
+      priceOracle: PriceOracle;
     }>;
   };
   stakedValidatorsStateFixture: {

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -158,6 +158,7 @@ export interface Fixtures {
       liquidToken: LiquidityToken;
       aprCalculator: APRCalculator;
       vestingManagerFactory: VestingManagerFactory;
+      priceOracle: PriceOracle;
       rewardWallet: RewardWallet;
     }>;
   };


### PR DESCRIPTION
Add Price Oracle - active validators can vote on price and when 61% of the power agrees with a minimum of 4 votes, it applies the change and sends a transaction to the APR calculator to update it! The vote still counts if the external call to the APR calculator fails!
Change Price module
Add tests for Price Oracle - fixtures, helper functions too
Modify tests in the APRCalculator to work properly with the Oracle