### PR TITLE
209 add a function to give us the generated rewards for a validator reward  all the bonuses

### DIFF
--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -50,15 +50,14 @@ interface IVestedDelegation is IDelegation {
     ) external view returns (uint256);
 
     /**
-     * @notice Calculates the delegators's generated rewards that are unclaimed
+     * @notice Calculates the delegators's pending (unclaimed) rewards for the position + additional reward, if any
      * @param staker Address of validator
      * @param delegator Address of delegator
-     * @param epochNumber Epoch where the last claimable reward is distributed
-     * We need it because not all rewards are matured at the moment of claiming
+     * @param epochNumber Epoch where the last reward for the vesting period is distributed
      * @param balanceChangeIndex Whether to redelegate the claimed rewards
-     * @return reward Unclaimed rewards expected by the delegator from a staker (in HYDRA wei)
+     * @return reward Pending rewards expected by the delegator from a staker (in HYDRA wei)
      */
-    function calculateExpectedPositionReward(
+    function calculatePositionPendingReward(
         address staker,
         address delegator,
         uint256 epochNumber,

--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -50,18 +50,18 @@ interface IVestedDelegation is IDelegation {
     ) external view returns (uint256);
 
     /**
-     * @notice Calculates the delegators's pending rewards for the position + additional reward, if any
+     * @notice Calculates the delegators's total rewards distributed (pending and claimable).
+     * Pending - such that are not matured so not claimable yet.
+     * Claimable - such that are matured and claimable.
      * @param staker Address of validator
      * @param delegator Address of delegator
-     * @param maturedReward The reward that has already been matured
      * @param epochNumber Epoch where the last reward for the vesting period is distributed
      * @param balanceChangeIndex Whether to redelegate the claimed rewards for the full position period
      * @return reward Pending rewards expected by the delegator from a staker (in HYDRA wei)
      */
-    function calculatePositionPendingReward(
+    function calculatePositionTotalReward(
         address staker,
         address delegator,
-        uint256 maturedReward,
         uint256 epochNumber,
         uint256 balanceChangeIndex
     ) external view returns (uint256 reward);

--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -53,9 +53,17 @@ interface IVestedDelegation is IDelegation {
      * @notice Calculates the delegators's generated rewards that are unclaimed
      * @param staker Address of validator
      * @param delegator Address of delegator
+     * @param epochNumber Epoch where the last claimable reward is distributed
+     * We need it because not all rewards are matured at the moment of claiming
+     * @param balanceChangeIndex Whether to redelegate the claimed rewards
      * @return reward Unclaimed rewards expected by the delegator from a staker (in HYDRA wei)
      */
-    function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward);
+    function calculateExpectedPositionReward(
+        address staker,
+        address delegator,
+        uint256 epochNumber,
+        uint256 balanceChangeIndex
+    ) external view returns (uint256 reward);
 
     /**
      * @notice Gets the RPS values for a staker in a given epoch range.

--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -34,7 +34,7 @@ interface IVestedDelegation is IDelegation {
     error NotVestingManager();
 
     /**
-     * @notice Gets delegators's matured unclaimed rewards for a position
+     * @notice Calculates position's claimable rewards
      * @param staker Address of validator
      * @param delegator Address of delegator
      * @param epochNumber Epoch where the last claimable reward is distributed
@@ -42,7 +42,7 @@ interface IVestedDelegation is IDelegation {
      * @param balanceChangeIndex Whether to redelegate the claimed rewards
      * @return Delegator's unclaimed rewards with staker (in HYDRA wei)
      */
-    function getDelegatorPositionReward(
+    function calculatePositionClaimableReward(
         address staker,
         address delegator,
         uint256 epochNumber,
@@ -50,16 +50,18 @@ interface IVestedDelegation is IDelegation {
     ) external view returns (uint256);
 
     /**
-     * @notice Calculates the delegators's pending (unclaimed) rewards for the position + additional reward, if any
+     * @notice Calculates the delegators's pending rewards for the position + additional reward, if any
      * @param staker Address of validator
      * @param delegator Address of delegator
+     * @param maturedReward The reward that has already been matured
      * @param epochNumber Epoch where the last reward for the vesting period is distributed
-     * @param balanceChangeIndex Whether to redelegate the claimed rewards
+     * @param balanceChangeIndex Whether to redelegate the claimed rewards for the full position period
      * @return reward Pending rewards expected by the delegator from a staker (in HYDRA wei)
      */
     function calculatePositionPendingReward(
         address staker,
         address delegator,
+        uint256 maturedReward,
         uint256 epochNumber,
         uint256 balanceChangeIndex
     ) external view returns (uint256 reward);
@@ -134,7 +136,8 @@ interface IVestedDelegation is IDelegation {
     function swapVestedPositionStaker(address oldStaker, address newStaker) external;
 
     /**
-     * @notice Claims reward for the vest manager (delegator).
+     * @notice Claims reward for the vest manager (delegator) and distribute it to the desired address.
+     * @dev It can be called only by the vest manager
      * @param staker Validator to claim from
      * @param to Address to transfer the reward to
      * @param epochNumber Epoch where the last claimable reward is distributed

--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -53,7 +53,7 @@ interface IVestedDelegation is IDelegation {
      * @notice Calculates the delegators's generated rewards that are unclaimed
      * @param staker Address of validator
      * @param delegator Address of delegator
-     * @return reward Delegator's unclaimed rewards with staker (in HYDRA wei)
+     * @return reward Unclaimed rewards expected by the delegator from a staker (in HYDRA wei)
      */
     function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward);
 

--- a/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/IVestedDelegation.sol
@@ -50,6 +50,14 @@ interface IVestedDelegation is IDelegation {
     ) external view returns (uint256);
 
     /**
+     * @notice Calculates the delegators's generated rewards that are unclaimed
+     * @param staker Address of validator
+     * @param delegator Address of delegator
+     * @return reward Delegator's unclaimed rewards with staker (in HYDRA wei)
+     */
+    function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward);
+
+    /**
      * @notice Gets the RPS values for a staker in a given epoch range.
      * @param staker Validator that is deleagted to
      * @param startEpoch Start epoch for values

--- a/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
@@ -283,7 +283,6 @@ abstract contract VestedDelegation is
             return;
         }
 
-        uint256 sumReward;
         DelegationPool storage delegationPool = delegationPools[staker];
 
         // distribute the proper vesting reward
@@ -296,7 +295,7 @@ abstract contract VestedDelegation is
 
         uint256 reward = delegationPool.claimRewards(msg.sender, epochRPS, balance, correction);
         reward = _applyVestingAPR(position, reward);
-        sumReward += reward;
+        uint256 sumReward = reward;
 
         // If the full maturing period is finished, withdraw also the reward made after the vesting period
         if (block.timestamp > position.end + position.duration) {

--- a/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
@@ -102,7 +102,7 @@ abstract contract VestedDelegation is
         uint256 reward = _applyVestingAPR(position, rewardIndex);
 
         // If the full maturing period is finished, calculate also the reward made after the vesting period
-        if (block.timestamp > position.end + position.duration) {
+        if (block.timestamp >= position.end + position.duration) {
             reward += _calcPositionAdditionalReward(delegationPool, delegator, rewardIndex);
         }
 
@@ -335,7 +335,7 @@ abstract contract VestedDelegation is
         reward = _applyVestingAPR(position, reward);
 
         // If the full maturing period is finished, withdraw also the reward made after the vesting period
-        if (block.timestamp > position.end + position.duration) {
+        if (block.timestamp >= position.end + position.duration) {
             uint256 additionalReward = delegationPool.claimRewards(msg.sender);
             reward += aprCalculatorContract.applyBaseAPR(additionalReward);
         }
@@ -590,13 +590,13 @@ abstract contract VestedDelegation is
     ) private view returns (uint256 rps, uint256 balance, int256 correction) {
         uint256 matureEnd = position.end + position.duration;
         uint256 alreadyMatured;
-        // If full mature period is finished, the full reward up to the end of the vesting must be matured
-        if (matureEnd < block.timestamp) {
-            alreadyMatured = position.end;
-        } else {
-            // rewardPerShare must be fetched from the history records
+        // If full mature period is not finished, rewardPerShare must be fetched from the history records
+        if (block.timestamp < matureEnd) {
             uint256 maturedPeriod = block.timestamp - position.end;
             alreadyMatured = position.start + maturedPeriod;
+        } else {
+            // otherwise the full reward up to the end of the vesting must be matured
+            alreadyMatured = position.end;
         }
 
         // return the reward params

--- a/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
@@ -110,6 +110,14 @@ abstract contract VestedDelegation is
     /**
      * @inheritdoc IVestedDelegation
      */
+    function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward) {
+        VestingPosition memory position = vestedDelegationPositions[staker][delegator];
+        reward = _applyVestingAPR(position, getRawDelegatorReward(staker, delegator));
+    }
+
+    /**
+     * @inheritdoc IVestedDelegation
+     */
     function getRPSValues(address staker, uint256 startEpoch, uint256 endEpoch) external view returns (RPS[] memory) {
         require(startEpoch <= endEpoch, "Invalid args");
 
@@ -264,7 +272,12 @@ abstract contract VestedDelegation is
     /**
      * @inheritdoc IVestedDelegation
      */
-    function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external onlyManager {
+    function claimPositionReward(
+        address staker,
+        address to,
+        uint256 epochNumber,
+        uint256 balanceChangeIndex
+    ) external onlyManager {
         VestingPosition memory position = vestedDelegationPositions[staker][msg.sender];
         if (_noRewardConditions(position)) {
             return;

--- a/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
+++ b/contracts/HydraDelegation/modules/VestedDelegation/VestedDelegation.sol
@@ -91,6 +91,7 @@ abstract contract VestedDelegation is
         // fetch the proper vesting reward params for the matured period
         (uint256 epochRPS, uint256 balance, int256 correction) = _getMaturedRewardParams(
             staker,
+            delegator,
             position,
             epochNumber,
             balanceChangeIndex
@@ -326,6 +327,7 @@ abstract contract VestedDelegation is
         // fetch the proper vesting reward params for the matured period
         (uint256 epochRPS, uint256 balance, int256 correction) = _getMaturedRewardParams(
             staker,
+            msg.sender,
             position,
             epochNumber,
             balanceChangeIndex
@@ -577,12 +579,14 @@ abstract contract VestedDelegation is
     /**
      * @notice Gets the reward parameters for a given position, epoch number and balance change index
      * @param staker Address of the validator
+     * @param manager Address of the vest manager
      * @param position The vested position
      * @param epochNumber Epoch number
      * @param balanceChangeIndex Index of the balance change
      */
     function _getMaturedRewardParams(
         address staker,
+        address manager,
         VestingPosition memory position,
         uint256 epochNumber,
         uint256 balanceChangeIndex
@@ -599,7 +603,7 @@ abstract contract VestedDelegation is
         }
 
         // return the reward params
-        return _rewardParams(staker, msg.sender, alreadyMatured, epochNumber, balanceChangeIndex);
+        return _rewardParams(staker, manager, alreadyMatured, epochNumber, balanceChangeIndex);
     }
 
     /**

--- a/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
@@ -40,13 +40,10 @@ interface IVestedStaking {
     function claimStakingRewards(uint256 rewardHistoryIndex) external;
 
     /**
-     * @notice Calculates the staker's generated rewards that are unclaimed
+     * @notice Calculates the staker's pending (unclaimed) position rewards
      * @param staker The address of the staker
      * @param rewardHistoryIndex The index of the reward history to calculate rewards from
-     * @return Unclaimed rewards expected by the vested staker's position (in HYDRA wei)
+     * @return Pending rewards expected by the vested staker's position (in HYDRA wei)
      */
-    function calculateExpectedPositionReward(
-        address staker,
-        uint256 rewardHistoryIndex
-    ) external view returns (uint256);
+    function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256);
 }

--- a/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
@@ -38,4 +38,15 @@ interface IVestedStaking {
      * @param rewardHistoryIndex The index of the reward history to claim rewards from
      */
     function claimStakingRewards(uint256 rewardHistoryIndex) external;
+
+    /**
+     * @notice Calculates the staker's generated rewards that are unclaimed
+     * @param staker The address of the staker
+     * @param rewardHistoryIndex The index of the reward history to calculate rewards from
+     * @return Unclaimed rewards expected by the vested staker's position (in HYDRA wei)
+     */
+    function calculateExpectedPositionReward(
+        address staker,
+        uint256 rewardHistoryIndex
+    ) external view returns (uint256);
 }

--- a/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
@@ -9,6 +9,26 @@ struct StakingRewardsHistory {
 
 interface IVestedStaking {
     /**
+     * @notice Calculates the staker's vested position claimable (already matured) rewards.
+     * @param staker The address of the staker
+     * @param rewardHistoryIndex The index of the reward history at time that is already matured
+     * @return claimable reward of the staker
+     **/
+    function calculatePositionClaimableReward(
+        address staker,
+        uint256 rewardHistoryIndex
+    ) external view returns (uint256);
+
+    /**
+     * @notice Calculates the staker's total (pending + claimable) rewards.
+     * Pending - such that are not matured so not claimable yet.
+     * Claimable - such that are matured and claimable.
+     * @param staker The address of the staker
+     * @return Pending rewards expected by the vested staker's position (in HYDRA wei)
+     */
+    function calculatePositionTotalReward(address staker) external view returns (uint256);
+
+    /**
      * @notice Returns historical records of the staking rewards of the user
      * @param staker The address of the staker
      * @return stakingRewardsHistory array with the historical records of the staking rewards of the user
@@ -38,12 +58,4 @@ interface IVestedStaking {
      * @param rewardHistoryIndex The index of the reward history to claim rewards from
      */
     function claimStakingRewards(uint256 rewardHistoryIndex) external;
-
-    /**
-     * @notice Calculates the staker's pending position rewards
-     * @param staker The address of the staker
-     * @param rewardHistoryIndex The index of the reward history to calculate rewards from
-     * @return Pending rewards expected by the vested staker's position (in HYDRA wei)
-     */
-    function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256);
 }

--- a/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/IVestedStaking.sol
@@ -40,7 +40,7 @@ interface IVestedStaking {
     function claimStakingRewards(uint256 rewardHistoryIndex) external;
 
     /**
-     * @notice Calculates the staker's pending (unclaimed) position rewards
+     * @notice Calculates the staker's pending position rewards
      * @param staker The address of the staker
      * @param rewardHistoryIndex The index of the reward history to calculate rewards from
      * @return Pending rewards expected by the vested staker's position (in HYDRA wei)

--- a/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
@@ -91,6 +91,22 @@ abstract contract VestedStaking is IVestedStaking, Staking, Vesting {
         emit StakingRewardsClaimed(msg.sender, rewards);
     }
 
+    /**
+     * @inheritdoc IVestedStaking
+     */
+    function calculateExpectedPositionReward(
+        address staker,
+        uint256 rewardHistoryIndex
+    ) external view returns (uint256) {
+        StakingRewardsHistory memory rewardData = stakingRewardsHistory[staker][rewardHistoryIndex];
+
+        if (rewardData.totalReward > stakingRewards[staker].taken) {
+            return rewardData.totalReward - stakingRewards[staker].taken;
+        }
+
+        return 0;
+    }
+
     // _______________ Internal functions _______________
 
     /**

--- a/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
@@ -52,7 +52,7 @@ abstract contract VestedStaking is IVestedStaking, Staking, Vesting {
      * @inheritdoc IVestedStaking
      */
     function calculatePositionTotalReward(address staker) external view returns (uint256) {
-        return stakingRewards[staker].total;
+        return unclaimedRewards(staker);
     }
 
     /**

--- a/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
+++ b/contracts/HydraStaking/modules/VestedStaking/VestedStaking.sol
@@ -94,7 +94,7 @@ abstract contract VestedStaking is IVestedStaking, Staking, Vesting {
     /**
      * @inheritdoc IVestedStaking
      */
-    function calculateExpectedPositionReward(
+    function calculatePositionPendingReward(
         address staker,
         uint256 rewardHistoryIndex
     ) external view returns (uint256) {

--- a/contracts/common/Vesting/VestedPositionLib.sol
+++ b/contracts/common/Vesting/VestedPositionLib.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.17;
 import {VestingPosition} from "./IVesting.sol";
 
 library VestedPositionLib {
-
     /**
      * @notice Check if the current time is between start and end time of the position
      * @param position Vesting position
@@ -13,6 +12,7 @@ library VestedPositionLib {
     function isActive(VestingPosition memory position) internal view returns (bool) {
         return position.start < block.timestamp && block.timestamp < position.end;
     }
+
     /**
      * @notice Check if the current time is between end of the position, but not all rewards are matured yet (needs double duration for maturing)
      * @param position Vesting position

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -315,7 +315,7 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 | delegator | address | Address of delegator |
 | maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -231,7 +231,7 @@ The threshold for the maximum number of allowed balance changes
 function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
 ```
 
-Gets delegators&#39;s generated rewards for a position that are not claimed yet
+Calculates the delegators&#39;s generated rewards that are unclaimed
 
 
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -246,7 +246,7 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### calculateOwedLiquidTokens
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -225,31 +225,6 @@ The threshold for the maximum number of allowed balance changes
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### calculateExpectedPositionReward
-
-```solidity
-function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
-```
-
-Calculates the delegators&#39;s generated rewards that are unclaimed
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
-
 ### calculateOwedLiquidTokens
 
 ```solidity
@@ -296,6 +271,31 @@ Calculates the penalty for the position.
 | Name | Type | Description |
 |---|---|---|
 | penalty | uint256 | undefined |
+
+### calculatePositionPendingReward
+
+```solidity
+function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Pending rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### changeMinDelegation
 
@@ -536,7 +536,7 @@ Gets the delegation pool params history for a staker and delegator.
 ### getDelegatorPositionReward
 
 ```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
 Gets delegators&#39;s matured unclaimed rewards for a position
@@ -556,7 +556,7 @@ Gets delegators&#39;s matured unclaimed rewards for a position
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -228,7 +228,7 @@ The threshold for the maximum number of allowed balance changes
 ### calculateExpectedPositionReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Calculates the delegators&#39;s generated rewards that are unclaimed
@@ -241,6 +241,8 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
 
 #### Returns
 
@@ -534,7 +536,7 @@ Gets the delegation pool params history for a staker and delegator.
 ### getDelegatorPositionReward
 
 ```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 sumReward)
+function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Gets delegators&#39;s matured unclaimed rewards for a position
@@ -554,7 +556,7 @@ Gets delegators&#39;s matured unclaimed rewards for a position
 
 | Name | Type | Description |
 |---|---|---|
-| sumReward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -225,6 +225,29 @@ The threshold for the maximum number of allowed balance changes
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+```
+
+Gets delegators&#39;s generated rewards for a position that are not claimed yet
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculateOwedLiquidTokens
 
 ```solidity

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -297,13 +297,13 @@ Calculates the penalty for the position.
 |---|---|---|
 | penalty | uint256 | undefined |
 
-### calculatePositionPendingReward
+### calculatePositionTotalReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+function calculatePositionTotalReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
-Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
+Calculates the delegators&#39;s total rewards distributed (pending and claimable). Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -313,7 +313,6 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
-| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
 | balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 

--- a/docs/HydraDelegation/HydraDelegation.md
+++ b/docs/HydraDelegation/HydraDelegation.md
@@ -248,6 +248,31 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 |---|---|---|
 | _0 | uint256 | The amount of liquid tokens the user owes to the protocol |
 
+### calculatePositionClaimableReward
+
+```solidity
+function calculatePositionClaimableReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates position&#39;s claimable rewards
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -275,10 +300,10 @@ Calculates the penalty for the position.
 ### calculatePositionPendingReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
-Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
 
 
 
@@ -288,8 +313,9 @@ Calculates the delegators&#39;s pending (unclaimed) rewards for the position + a
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 
@@ -351,9 +377,9 @@ Claims rewards for delegator for staker
 function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external nonpayable
 ```
 
-Claims reward for the vest manager (delegator).
+Claims reward for the vest manager (delegator) and distribute it to the desired address.
 
-
+*It can be called only by the vest manager*
 
 #### Parameters
 
@@ -532,31 +558,6 @@ Gets the delegation pool params history for a staker and delegator.
 | Name | Type | Description |
 |---|---|---|
 | _0 | DelegationPoolParams[] | undefined |
-
-### getDelegatorPositionReward
-
-```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
-```
-
-Gets delegators&#39;s matured unclaimed rewards for a position
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -10,6 +10,29 @@
 
 ## Methods
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+```
+
+Gets delegators&#39;s generated rewards for a position that are not claimed yet
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculateOwedLiquidTokens
 
 ```solidity

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -82,13 +82,13 @@ Calculates the penalty for the position.
 |---|---|---|
 | penalty | uint256 | undefined |
 
-### calculatePositionPendingReward
+### calculatePositionTotalReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function calculatePositionTotalReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
-Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
+Calculates the delegators&#39;s total rewards distributed (pending and claimable). Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -98,7 +98,6 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
-| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
 | balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -100,7 +100,7 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 | delegator | address | Address of delegator |
 | maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -31,7 +31,7 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### calculateOwedLiquidTokens
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -10,31 +10,6 @@
 
 ## Methods
 
-### calculateExpectedPositionReward
-
-```solidity
-function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
-```
-
-Calculates the delegators&#39;s generated rewards that are unclaimed
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
-
 ### calculateOwedLiquidTokens
 
 ```solidity
@@ -81,6 +56,31 @@ Calculates the penalty for the position.
 | Name | Type | Description |
 |---|---|---|
 | penalty | uint256 | undefined |
+
+### calculatePositionPendingReward
+
+```solidity
+function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+```
+
+Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Pending rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### changeMinDelegation
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -16,7 +16,7 @@
 function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
 ```
 
-Gets delegators&#39;s generated rewards for a position that are not claimed yet
+Calculates the delegators&#39;s generated rewards that are unclaimed
 
 
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -33,6 +33,31 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 |---|---|---|
 | _0 | uint256 | The amount of liquid tokens the user owes to the protocol |
 
+### calculatePositionClaimableReward
+
+```solidity
+function calculatePositionClaimableReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates position&#39;s claimable rewards
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -60,10 +85,10 @@ Calculates the penalty for the position.
 ### calculatePositionPendingReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
-Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
 
 
 
@@ -73,8 +98,9 @@ Calculates the delegators&#39;s pending (unclaimed) rewards for the position + a
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 
@@ -136,9 +162,9 @@ Claims rewards for delegator for staker
 function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external nonpayable
 ```
 
-Claims reward for the vest manager (delegator).
+Claims reward for the vest manager (delegator) and distribute it to the desired address.
 
-
+*It can be called only by the vest manager*
 
 #### Parameters
 
@@ -245,31 +271,6 @@ Gets the delegation pool params history for a staker and delegator.
 | Name | Type | Description |
 |---|---|---|
 | _0 | DelegationPoolParams[] | undefined |
-
-### getDelegatorPositionReward
-
-```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
-```
-
-Gets delegators&#39;s matured unclaimed rewards for a position
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/IHydraDelegation.md
+++ b/docs/HydraDelegation/IHydraDelegation.md
@@ -13,7 +13,7 @@
 ### calculateExpectedPositionReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Calculates the delegators&#39;s generated rewards that are unclaimed
@@ -26,6 +26,8 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
 
 #### Returns
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -59,13 +59,13 @@ Calculates the penalty for the position.
 |---|---|---|
 | penalty | uint256 | undefined |
 
-### calculatePositionPendingReward
+### calculatePositionTotalReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function calculatePositionTotalReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
-Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
+Calculates the delegators&#39;s total rewards distributed (pending and claimable). Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -75,7 +75,6 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
-| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
 | balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -77,7 +77,7 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 | delegator | address | Address of delegator |
 | maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -10,31 +10,6 @@
 
 ## Methods
 
-### calculateExpectedPositionReward
-
-```solidity
-function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
-```
-
-Calculates the delegators&#39;s generated rewards that are unclaimed
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
-
 ### calculatePositionPenalty
 
 ```solidity
@@ -58,6 +33,31 @@ Calculates the penalty for the position.
 | Name | Type | Description |
 |---|---|---|
 | penalty | uint256 | undefined |
+
+### calculatePositionPendingReward
+
+```solidity
+function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+```
+
+Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Pending rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### changeMinDelegation
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -16,7 +16,7 @@
 function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
 ```
 
-Gets delegators&#39;s generated rewards for a position that are not claimed yet
+Calculates the delegators&#39;s generated rewards that are unclaimed
 
 
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -31,7 +31,7 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### calculatePositionPenalty
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -13,7 +13,7 @@
 ### calculateExpectedPositionReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Calculates the delegators&#39;s generated rewards that are unclaimed
@@ -26,6 +26,8 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
 
 #### Returns
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -10,6 +10,31 @@
 
 ## Methods
 
+### calculatePositionClaimableReward
+
+```solidity
+function calculatePositionClaimableReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates position&#39;s claimable rewards
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -37,10 +62,10 @@ Calculates the penalty for the position.
 ### calculatePositionPendingReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
-Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
 
 
 
@@ -50,8 +75,9 @@ Calculates the delegators&#39;s pending (unclaimed) rewards for the position + a
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 
@@ -113,9 +139,9 @@ Claims rewards for delegator for staker
 function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external nonpayable
 ```
 
-Claims reward for the vest manager (delegator).
+Claims reward for the vest manager (delegator) and distribute it to the desired address.
 
-
+*It can be called only by the vest manager*
 
 #### Parameters
 
@@ -204,31 +230,6 @@ Gets the delegation pool params history for a staker and delegator.
 | Name | Type | Description |
 |---|---|---|
 | _0 | DelegationPoolParams[] | undefined |
-
-### getDelegatorPositionReward
-
-```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
-```
-
-Gets delegators&#39;s matured unclaimed rewards for a position
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/IVestedDelegation.md
@@ -10,6 +10,29 @@
 
 ## Methods
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+```
+
+Gets delegators&#39;s generated rewards for a position that are not claimed yet
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -92,7 +92,7 @@ The threshold for the maximum number of allowed balance changes
 ### calculateExpectedPositionReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Calculates the delegators&#39;s generated rewards that are unclaimed
@@ -105,6 +105,8 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
 
 #### Returns
 
@@ -335,7 +337,7 @@ Gets the delegation pool params history for a staker and delegator.
 ### getDelegatorPositionReward
 
 ```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 sumReward)
+function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
 ```
 
 Gets delegators&#39;s matured unclaimed rewards for a position
@@ -355,7 +357,7 @@ Gets delegators&#39;s matured unclaimed rewards for a position
 
 | Name | Type | Description |
 |---|---|---|
-| sumReward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -95,7 +95,7 @@ The threshold for the maximum number of allowed balance changes
 function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
 ```
 
-Gets delegators&#39;s generated rewards for a position that are not claimed yet
+Calculates the delegators&#39;s generated rewards that are unclaimed
 
 
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -138,13 +138,13 @@ Calculates the penalty for the position.
 |---|---|---|
 | penalty | uint256 | undefined |
 
-### calculatePositionPendingReward
+### calculatePositionTotalReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+function calculatePositionTotalReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
-Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
+Calculates the delegators&#39;s total rewards distributed (pending and claimable). Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -154,7 +154,6 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
-| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
 | balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -89,6 +89,29 @@ The threshold for the maximum number of allowed balance changes
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, address delegator) external view returns (uint256 reward)
+```
+
+Gets delegators&#39;s generated rewards for a position that are not claimed yet
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -89,6 +89,31 @@ The threshold for the maximum number of allowed balance changes
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### calculatePositionClaimableReward
+
+```solidity
+function calculatePositionClaimableReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates position&#39;s claimable rewards
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+
 ### calculatePositionPenalty
 
 ```solidity
@@ -116,10 +141,10 @@ Calculates the penalty for the position.
 ### calculatePositionPendingReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+function calculatePositionPendingReward(address staker, address delegator, uint256 maturedReward, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
-Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+Calculates the delegators&#39;s pending rewards for the position + additional reward, if any
 
 
 
@@ -129,8 +154,9 @@ Calculates the delegators&#39;s pending (unclaimed) rewards for the position + a
 |---|---|---|
 | staker | address | Address of validator |
 | delegator | address | Address of delegator |
+| maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 
@@ -192,9 +218,9 @@ Claims rewards for delegator for staker
 function claimPositionReward(address staker, address to, uint256 epochNumber, uint256 balanceChangeIndex) external nonpayable
 ```
 
-Claims reward for the vest manager (delegator).
+Claims reward for the vest manager (delegator) and distribute it to the desired address.
 
-
+*It can be called only by the vest manager*
 
 #### Parameters
 
@@ -333,31 +359,6 @@ Gets the delegation pool params history for a staker and delegator.
 | Name | Type | Description |
 |---|---|---|
 | _0 | DelegationPoolParams[] | undefined |
-
-### getDelegatorPositionReward
-
-```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
-```
-
-Gets delegators&#39;s matured unclaimed rewards for a position
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -110,7 +110,7 @@ Calculates the delegators&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### calculatePositionPenalty
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -89,31 +89,6 @@ The threshold for the maximum number of allowed balance changes
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### calculateExpectedPositionReward
-
-```solidity
-function calculateExpectedPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
-```
-
-Calculates the delegators&#39;s generated rewards that are unclaimed
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | Address of validator |
-| delegator | address | Address of delegator |
-| epochNumber | uint256 | Epoch where the last claimable reward is distributed We need it because not all rewards are matured at the moment of claiming |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| reward | uint256 | Unclaimed rewards expected by the delegator from a staker (in HYDRA wei) |
-
 ### calculatePositionPenalty
 
 ```solidity
@@ -137,6 +112,31 @@ Calculates the penalty for the position.
 | Name | Type | Description |
 |---|---|---|
 | penalty | uint256 | undefined |
+
+### calculatePositionPendingReward
+
+```solidity
+function calculatePositionPendingReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
+```
+
+Calculates the delegators&#39;s pending (unclaimed) rewards for the position + additional reward, if any
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | Address of validator |
+| delegator | address | Address of delegator |
+| epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Pending rewards expected by the delegator from a staker (in HYDRA wei) |
 
 ### changeMinDelegation
 
@@ -337,7 +337,7 @@ Gets the delegation pool params history for a staker and delegator.
 ### getDelegatorPositionReward
 
 ```solidity
-function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256 reward)
+function getDelegatorPositionReward(address staker, address delegator, uint256 epochNumber, uint256 balanceChangeIndex) external view returns (uint256)
 ```
 
 Gets delegators&#39;s matured unclaimed rewards for a position
@@ -357,7 +357,7 @@ Gets delegators&#39;s matured unclaimed rewards for a position
 
 | Name | Type | Description |
 |---|---|---|
-| reward | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
+| _0 | uint256 | Delegator&#39;s unclaimed rewards with staker (in HYDRA wei) |
 
 ### getDelegatorReward
 

--- a/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
+++ b/docs/HydraDelegation/modules/VestedDelegation/VestedDelegation.md
@@ -156,7 +156,7 @@ Calculates the delegators&#39;s pending rewards for the position + additional re
 | delegator | address | Address of delegator |
 | maturedReward | uint256 | The reward that has already been matured |
 | epochNumber | uint256 | Epoch where the last reward for the vesting period is distributed |
-| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period OLDparam epochNumber Epoch where the last claimable reward is distributed OLDparam balanceChangeIndex Whether to redelegate the claimed rewards for the matured period OLDparam posEndEpochNumber Epoch where the last reward for the vesting period is distributed OLDparam posEndBalChangeIndex Whether to redelegate the claimed rewards for the full position period |
+| balanceChangeIndex | uint256 | Whether to redelegate the claimed rewards for the full position period |
 
 #### Returns
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -198,29 +198,6 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
-### calculateExpectedPositionReward
-
-```solidity
-function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
-```
-
-Calculates the staker&#39;s generated rewards that are unclaimed
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| staker | address | The address of the staker |
-| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
-
 ### calculateOwedLiquidTokens
 
 ```solidity
@@ -243,6 +220,29 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The amount of liquid tokens the user owes to the protocol |
+
+### calculatePositionPendingReward
+
+```solidity
+function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+```
+
+Calculates the staker&#39;s pending (unclaimed) position rewards
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Pending rewards expected by the vested staker&#39;s position (in HYDRA wei) |
 
 ### changeMinStake
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -198,6 +198,29 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+```
+
+Calculates the staker&#39;s generated rewards that are unclaimed
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
+
 ### calculateOwedLiquidTokens
 
 ```solidity

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -227,7 +227,7 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 function calculatePositionClaimableReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-
+Calculates the staker&#39;s vested position claimable (already matured) rewards.
 
 
 
@@ -235,14 +235,14 @@ function calculatePositionClaimableReward(address staker, uint256 rewardHistoryI
 
 | Name | Type | Description |
 |---|---|---|
-| staker | address | undefined |
-| rewardHistoryIndex | uint256 | undefined |
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history at time that is already matured |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | claimable reward of the staker* |
 
 ### calculatePositionTotalReward
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -221,13 +221,36 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 |---|---|---|
 | _0 | uint256 | The amount of liquid tokens the user owes to the protocol |
 
-### calculatePositionPendingReward
+### calculatePositionClaimableReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+function calculatePositionClaimableReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending position rewards
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | undefined |
+| rewardHistoryIndex | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### calculatePositionTotalReward
+
+```solidity
+function calculatePositionTotalReward(address staker) external view returns (uint256)
+```
+
+Calculates the staker&#39;s total (pending + claimable) rewards. Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -236,7 +259,6 @@ Calculates the staker&#39;s pending position rewards
 | Name | Type | Description |
 |---|---|---|
 | staker | address | The address of the staker |
-| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
 
 #### Returns
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -227,7 +227,7 @@ Returns the amount of liquid tokens the user owes to the protocol based on the g
 function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending (unclaimed) position rewards
+Calculates the staker&#39;s pending position rewards
 
 
 

--- a/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
@@ -34,6 +34,29 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
+### calculatePositionClaimableReward
+
+```solidity
+function calculatePositionClaimableReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+```
+
+Calculates the staker&#39;s vested position claimable (already matured) rewards.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history at time that is already matured |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | claimable reward of the staker* |
+
 ### calculatePositionTotalReward
 
 ```solidity

--- a/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
@@ -34,13 +34,13 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
-### calculatePositionPendingReward
+### calculatePositionTotalReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+function calculatePositionTotalReward(address staker) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending position rewards
+Calculates the staker&#39;s total (pending + claimable) rewards. Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -49,7 +49,6 @@ Calculates the staker&#39;s pending position rewards
 | Name | Type | Description |
 |---|---|---|
 | staker | address | The address of the staker |
-| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
 
 #### Returns
 

--- a/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
@@ -40,7 +40,7 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending (unclaimed) position rewards
+Calculates the staker&#39;s pending position rewards
 
 
 

--- a/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
@@ -34,13 +34,13 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
-### calculateExpectedPositionReward
+### calculatePositionPendingReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s generated rewards that are unclaimed
+Calculates the staker&#39;s pending (unclaimed) position rewards
 
 
 
@@ -55,7 +55,7 @@ Calculates the staker&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
+| _0 | uint256 | Pending rewards expected by the vested staker&#39;s position (in HYDRA wei) |
 
 ### claimStakingRewards
 

--- a/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/IVestedStaking.md
@@ -34,6 +34,29 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+```
+
+Calculates the staker&#39;s generated rewards that are unclaimed
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
+
 ### claimStakingRewards
 
 ```solidity

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -102,7 +102,7 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending (unclaimed) position rewards
+Calculates the staker&#39;s pending position rewards
 
 
 

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -96,13 +96,36 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
-### calculatePositionPendingReward
+### calculatePositionClaimableReward
 
 ```solidity
-function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+function calculatePositionClaimableReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s pending position rewards
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | undefined |
+| rewardHistoryIndex | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### calculatePositionTotalReward
+
+```solidity
+function calculatePositionTotalReward(address staker) external view returns (uint256)
+```
+
+Calculates the staker&#39;s total (pending + claimable) rewards. Pending - such that are not matured so not claimable yet. Claimable - such that are matured and claimable.
 
 
 
@@ -111,7 +134,6 @@ Calculates the staker&#39;s pending position rewards
 | Name | Type | Description |
 |---|---|---|
 | staker | address | The address of the staker |
-| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
 
 #### Returns
 

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -96,6 +96,29 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
+### calculateExpectedPositionReward
+
+```solidity
+function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+```
+
+Calculates the staker&#39;s generated rewards that are unclaimed
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history to calculate rewards from |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
+
 ### changeMinStake
 
 ```solidity

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -102,7 +102,7 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 function calculatePositionClaimableReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-
+Calculates the staker&#39;s vested position claimable (already matured) rewards.
 
 
 
@@ -110,14 +110,14 @@ function calculatePositionClaimableReward(address staker, uint256 rewardHistoryI
 
 | Name | Type | Description |
 |---|---|---|
-| staker | address | undefined |
-| rewardHistoryIndex | uint256 | undefined |
+| staker | address | The address of the staker |
+| rewardHistoryIndex | uint256 | The index of the reward history at time that is already matured |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | claimable reward of the staker* |
 
 ### calculatePositionTotalReward
 

--- a/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
+++ b/docs/HydraStaking/modules/VestedStaking/VestedStaking.md
@@ -96,13 +96,13 @@ Returns the penalty and reward that will be burned, if vested stake position is 
 | penalty | uint256 | for the staker |
 | reward | uint256 | of the staker |
 
-### calculateExpectedPositionReward
+### calculatePositionPendingReward
 
 ```solidity
-function calculateExpectedPositionReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
+function calculatePositionPendingReward(address staker, uint256 rewardHistoryIndex) external view returns (uint256)
 ```
 
-Calculates the staker&#39;s generated rewards that are unclaimed
+Calculates the staker&#39;s pending (unclaimed) position rewards
 
 
 
@@ -117,7 +117,7 @@ Calculates the staker&#39;s generated rewards that are unclaimed
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Unclaimed rewards expected by the vested staker&#39;s position (in HYDRA wei) |
+| _0 | uint256 | Pending rewards expected by the vested staker&#39;s position (in HYDRA wei) |
 
 ### changeMinStake
 

--- a/test/HydraDelegation/HydraDelegation.test.ts
+++ b/test/HydraDelegation/HydraDelegation.test.ts
@@ -371,7 +371,7 @@ export function RunHydraDelegationTests(): void {
           "claimVestedPositionReward"
         )
           .to.be.revertedWithCustomError(hydraDelegation, "DelegateRequirement")
-          .withArgs("vesting", "INVALID_EPOCH");
+          .withArgs("vesting", ERRORS.vesting.invalidEpoch);
 
         // commit epoch
         await commitEpoch(
@@ -386,7 +386,7 @@ export function RunHydraDelegationTests(): void {
           "claimVestedPositionReward2"
         )
           .to.be.revertedWithCustomError(hydraDelegation, "DelegateRequirement")
-          .withArgs("vesting", "WRONG_RPS");
+          .withArgs("vesting", ERRORS.vesting.wrongRPS);
       });
 
       it("should properly claim reward when not fully matured", async function () {

--- a/test/HydraDelegation/HydraDelegation.test.ts
+++ b/test/HydraDelegation/HydraDelegation.test.ts
@@ -20,7 +20,7 @@ import { RunVestedDelegationTests } from "./VestedDelegation.test";
 import { LiquidityToken__factory } from "../../typechain-types";
 
 export function RunHydraDelegationTests(): void {
-  describe.only("", function () {
+  describe("", function () {
     describe("HydraDelegation initializations", function () {
       it("should validate default values when HydraDelegation deployed", async function () {
         const { hydraDelegation } = await loadFixture(this.fixtures.presetHydraChainStateFixture);

--- a/test/HydraDelegation/HydraDelegation.test.ts
+++ b/test/HydraDelegation/HydraDelegation.test.ts
@@ -7,7 +7,7 @@ import * as hre from "hardhat";
 import { ERRORS, WEEK, EPOCHS_YEAR, MAX_COMMISSION, INITIAL_COMMISSION, DEADLINE } from "../constants";
 import {
   commitEpochs,
-  retrieveRPSData,
+  getClaimableRewardRPSData,
   commitEpoch,
   applyVestingAPR,
   getPermitSignature,
@@ -20,7 +20,7 @@ import { RunVestedDelegationTests } from "./VestedDelegation.test";
 import { LiquidityToken__factory } from "../../typechain-types";
 
 export function RunHydraDelegationTests(): void {
-  describe("", function () {
+  describe.only("", function () {
     describe("HydraDelegation initializations", function () {
       it("should validate default values when HydraDelegation deployed", async function () {
         const { hydraDelegation } = await loadFixture(this.fixtures.presetHydraChainStateFixture);
@@ -359,7 +359,7 @@ export function RunHydraDelegationTests(): void {
         await time.increase(WEEK * 52);
 
         // prepare params for call
-        const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+        const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
           systemHydraChain,
           hydraDelegation,
           delegatedValidator.address,
@@ -418,7 +418,7 @@ export function RunHydraDelegationTests(): void {
         );
 
         // prepare params for call
-        const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+        const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
           systemHydraChain,
           hydraDelegation,
           delegatedValidator.address,
@@ -470,7 +470,7 @@ export function RunHydraDelegationTests(): void {
         const expectedFinalReward = expectedReward.add(expectedAdditionalReward);
 
         // prepare params for call
-        const { position, epochNum, balanceChangeIndex } = await retrieveRPSData(
+        const { position, epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
           systemHydraChain,
           hydraDelegation,
           delegatedValidator.address,

--- a/test/HydraDelegation/HydraDelegation.test.ts
+++ b/test/HydraDelegation/HydraDelegation.test.ts
@@ -9,7 +9,7 @@ import {
   commitEpochs,
   retrieveRPSData,
   commitEpoch,
-  calculateExpectedReward,
+  applyVestingAPR,
   getPermitSignature,
   calcLiquidTokensToDistributeOnVesting,
 } from "../helper";
@@ -406,7 +406,7 @@ export function RunHydraDelegationTests(): void {
         const base = await aprCalculator.base();
         const vestBonus = await aprCalculator.getVestingBonus(1);
         const rsi = await aprCalculator.rsi();
-        const expectedReward = await calculateExpectedReward(base, vestBonus, rsi, baseReward);
+        const expectedReward = applyVestingAPR(base, vestBonus, rsi, baseReward);
 
         // commit epoch, so more reward is added that must not be claimed now
         await commitEpoch(
@@ -451,7 +451,7 @@ export function RunHydraDelegationTests(): void {
         const base = await aprCalculator.base();
         const vestBonus = await aprCalculator.getVestingBonus(1);
         const rsi = await aprCalculator.rsi();
-        const expectedReward = await calculateExpectedReward(base, vestBonus, rsi, baseReward);
+        const expectedReward = applyVestingAPR(base, vestBonus, rsi, baseReward);
 
         // more rewards to be distributed
         await commitEpoch(

--- a/test/HydraDelegation/SwapVestedPositionStaker.test.ts
+++ b/test/HydraDelegation/SwapVestedPositionStaker.test.ts
@@ -3,7 +3,7 @@ import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 
 import { DAY, ERRORS, WEEK } from "../constants";
-import { commitEpoch, commitEpochs, retrieveRPSData } from "../helper";
+import { commitEpoch, commitEpochs, getClaimableRewardRPSData } from "../helper";
 
 export function RunSwapVestedPositionStakerTests(): void {
   it("should revert when not the vest manager owner", async function () {
@@ -129,7 +129,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     await commitEpochs(systemHydraChain, hydraStaking, [oldValidator, newValidator], 5, this.epochSize, DAY * 3);
 
     // prepare params for call
-    const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
       systemHydraChain,
       hydraDelegation,
       newValidator.address,
@@ -179,7 +179,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     await vestManager.connect(vestManagerOwner).cutVestedDelegatePosition(newValidator.address, this.minDelegation);
 
     // verify that there are rewards left to claim
-    const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
       systemHydraChain,
       hydraDelegation,
       newValidator.address,
@@ -187,7 +187,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     );
 
     expect(
-      await hydraDelegation.getDelegatorPositionReward(
+      await hydraDelegation.calculatePositionClaimableReward(
         newValidator.address,
         vestManager.address,
         epochNum,
@@ -304,7 +304,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     expect(rewardsBeforeClaim).to.be.gt(0);
 
     // prepare params for call
-    const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
       systemHydraChain,
       hydraDelegation,
       newValidator.address,
@@ -338,7 +338,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     expect(rewardsBeforeClaim).to.be.gt(0);
 
     // prepare params for call
-    const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
       systemHydraChain,
       hydraDelegation,
       newValidator.address,
@@ -371,7 +371,7 @@ export function RunSwapVestedPositionStakerTests(): void {
     expect(rewardsBeforeClaim, "rewardsBeforeClaim").to.be.gt(0);
 
     // prepare params for call
-    const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    const { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
       systemHydraChain,
       hydraDelegation,
       oldValidator.address,

--- a/test/HydraDelegation/VestedDelegation.test.ts
+++ b/test/HydraDelegation/VestedDelegation.test.ts
@@ -823,7 +823,7 @@ export function RunVestedDelegationTests(): void {
           .withArgs("vesting", ERRORS.vesting.invalidParamsIndex);
       });
 
-      it.only("should revert when get reward with late balance", async function () {
+      it("should revert when get reward with late balance", async function () {
         const { systemHydraChain, hydraStaking, hydraDelegation, vestManager, oldValidator, newValidator } =
           await loadFixture(this.fixtures.swappedPositionFixture);
 
@@ -1217,11 +1217,11 @@ export function RunVestedDelegationTests(): void {
         const { systemHydraChain, hydraStaking, hydraDelegation, vestManager, oldValidator, newValidator } =
           await loadFixture(this.fixtures.swappedPositionFixture);
 
-        // commit 4 epochs, 1 week each in order to mature the position and be able to claim
-        await commitEpochs(systemHydraChain, hydraStaking, [oldValidator, newValidator], 4, this.epochSize, WEEK + 1);
+        // commit 3 epochs, 1 week each in order to enter maturing period
+        await commitEpochs(systemHydraChain, hydraStaking, [oldValidator, newValidator], 3, this.epochSize, WEEK);
 
         // prepare params for call
-        const { epochNum } = await getClaimableRewardRPSData(
+        const { epochNum } = await getPendingRewardRPSData(
           systemHydraChain,
           hydraDelegation,
           oldValidator.address,
@@ -1270,7 +1270,6 @@ export function RunVestedDelegationTests(): void {
           this.fixtures.vestedDelegationFixture
         );
 
-        // vito
         // prepare params for call
         let { epochNum, balanceChangeIndex } = await getClaimableRewardRPSData(
           systemHydraChain,

--- a/test/HydraDelegation/VestedDelegation.test.ts
+++ b/test/HydraDelegation/VestedDelegation.test.ts
@@ -1287,7 +1287,7 @@ export function RunVestedDelegationTests(): void {
         expect(positionPendingReward).to.be.equal(expectedReward);
       });
 
-      it("should successfully calculate the pending reward for matured position", async function () {
+      it("should successfully calculate the pending reward for matured position and claim", async function () {
         const { systemHydraChain, hydraStaking, hydraDelegation, delegatedValidator, vestManager } = await loadFixture(
           this.fixtures.vestedDelegationFixture
         );

--- a/test/HydraDelegation/VestedDelegation.test.ts
+++ b/test/HydraDelegation/VestedDelegation.test.ts
@@ -196,14 +196,10 @@ export function RunVestedDelegationTests(): void {
         await time.increase(WEEK * 110);
 
         const vestingDuration = 52; // in weeks
-        let currentReward = await hydraDelegation.getRawDelegatorReward(
-          this.signers.validators[2].address,
-          vestManager.address
-        );
 
         await claimPositionRewards(hydraChain, hydraDelegation, vestManager, this.delegatedValidators[0]);
 
-        currentReward = await hydraDelegation.getRawDelegatorReward(
+        const currentReward = await hydraDelegation.getRawDelegatorReward(
           this.signers.validators[2].address,
           vestManager.address
         );
@@ -1127,7 +1123,7 @@ export function RunVestedDelegationTests(): void {
     });
 
     describe("calculateExpectedPositionReward()", async function () {
-      it("should successfully calculate the expected reward", async function () {
+      it("should calculate the expected position rewards", async function () {
         const { systemHydraChain, hydraDelegation, hydraStaking, vestingManagerFactory } = await loadFixture(
           this.fixtures.delegatedFixture
         );
@@ -1157,9 +1153,19 @@ export function RunVestedDelegationTests(): void {
           manager.address
         );
 
-        const managerRewards = await hydraDelegation.calculateExpectedPositionReward(
+        // prepare params for call
+        const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+          systemHydraChain,
+          hydraDelegation,
           validator.address,
           manager.address
+        );
+
+        const managerRewards = await hydraDelegation.calculateExpectedPositionReward(
+          validator.address,
+          manager.address,
+          epochNum,
+          balanceChangeIndex
         );
 
         expect(managerRewards).to.equal(expectedReward);

--- a/test/HydraStaking/VestedStaking.test.ts
+++ b/test/HydraStaking/VestedStaking.test.ts
@@ -326,7 +326,7 @@ export function RunVestedStakingTests(): void {
       });
     });
 
-    describe("calculateExpectedPositionReward()", async function () {
+    describe("calculatePositionPendingReward()", async function () {
       it("should calculate the expected rewards when maturing", async function () {
         const { systemHydraChain, hydraStaking } = await loadFixture(this.fixtures.vestingRewardsFixture);
 
@@ -353,7 +353,7 @@ export function RunVestedStakingTests(): void {
           position.end.sub(position.duration.div(2))
         );
 
-        const stakerRewards = await hydraStaking.calculateExpectedPositionReward(
+        const stakerRewards = await hydraStaking.calculatePositionPendingReward(
           this.staker.address,
           valRewardHistoryRecordIndex
         );
@@ -392,7 +392,7 @@ export function RunVestedStakingTests(): void {
           position.end.sub(position.duration.div(2))
         );
 
-        const takenRewards = await hydraStaking.calculateExpectedPositionReward(
+        const takenRewards = await hydraStaking.calculatePositionPendingReward(
           this.staker.address,
           valRewardHistoryRecordIndex
         );
@@ -420,7 +420,7 @@ export function RunVestedStakingTests(): void {
           valRewardHistoryRecordIndex
         );
 
-        const stakerRewards = await hydraStaking.calculateExpectedPositionReward(
+        const stakerRewards = await hydraStaking.calculatePositionPendingReward(
           this.staker.address,
           valRewardHistoryRecordIndex
         );

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -61,7 +61,10 @@ export const ERRORS = {
     newPositionUnavailable: "NEW_POSITION_UNAVAILABLE",
   },
   vesting: {
+    invalidEpoch: "INVALID_EPOCH",
+    wrongRPS: "WRONG_RPS",
     invalidParamsIndex: "INVALID_PARAMS_INDEX",
+    earlyBalanceChange: "EARLY_BALANCE_CHANGE",
   },
   accessControl: (account: string, role: string) => {
     return `AccessControl: account ${account.toLowerCase()} is missing role ${role}`;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -10,6 +10,7 @@ export const VALIDATOR_PKCHECK_PRECOMPILE_GAS = 150000;
 export const CHAIN_ID = 31337;
 export const INITIAL_COMMISSION = ethers.BigNumber.from(10);
 export const MAX_COMMISSION = ethers.BigNumber.from(100);
+export const HOUR = 60 * 60;
 export const DAY = 60 * 60 * 24;
 export const WEEK = DAY * 7;
 export const VESTING_DURATION_WEEKS = 10; // in weeks

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -315,11 +315,13 @@ export async function claimPositionRewards(
   vestManager: VestingManager,
   validator: string
 ) {
-  const position = await hydraDelegation.vestedDelegationPositions(validator, vestManager.address);
-  const currentEpochId = await hydraChain.currentEpochId();
-  const rpsValues = await hydraDelegation.getRPSValues(validator, 0, currentEpochId);
-  const rpsIndex = findProperRPSIndex(rpsValues, position.end);
-  await vestManager.claimVestedPositionReward(validator, rpsIndex, 0);
+  const { epochNum, balanceChangeIndex } = await retrieveRPSData(
+    hydraChain,
+    hydraDelegation,
+    validator,
+    vestManager.address
+  );
+  await vestManager.claimVestedPositionReward(validator, epochNum, balanceChangeIndex);
 }
 
 export async function createNewVestManager(vestingManagerFactory: VestingManagerFactory, owner: SignerWithAddress) {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -284,8 +284,6 @@ export async function retrieveRPSData(
   manager: string,
   maturedIn: number
 ) {
-  // const position = await hydraDelegation.vestedDelegationPositions(validator, manager);
-  // const maturedIn = await getClosestMaturedTimestamp(position);
   const currentEpochId = await hydraChain.currentEpochId();
   const rpsValues = await hydraDelegation.getRPSValues(validator, 0, currentEpochId);
   const epochNum = findProperRPSIndex(rpsValues, hre.ethers.BigNumber.from(maturedIn));

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -247,7 +247,6 @@ export async function getClaimableRewardRPSData(
   const position = await hydraDelegation.vestedDelegationPositions(validator, manager);
   const maturedIn = await getClosestMaturedTimestamp(position);
 
-  console.log("=== new, maturedIn: ", maturedIn);
   const { epochNum, balanceChangeIndex } = await retrieveRPSData(
     hydraChain,
     hydraDelegation,
@@ -289,7 +288,6 @@ export async function retrieveRPSData(
   // const maturedIn = await getClosestMaturedTimestamp(position);
   const currentEpochId = await hydraChain.currentEpochId();
   const rpsValues = await hydraDelegation.getRPSValues(validator, 0, currentEpochId);
-  console.log("=== new, rps values: ", rpsValues);
   const epochNum = findProperRPSIndex(rpsValues, hre.ethers.BigNumber.from(maturedIn));
   const delegationPoolParamsHistory = await hydraDelegation.getDelegationPoolParamsHistory(validator, manager);
   const balanceChangeIndex = findProperBalanceChangeIndex(

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -479,7 +479,8 @@ export async function getPermitSignature(
   );
 }
 
-export async function calculateExpectedPositionReward(
+// function that calculates the position reward and applies the vesting APR
+export async function calculateExpectedPositionRewardWithVestingAPR(
   hydraDelegation: HydraDelegation,
   validator: string,
   delegator: string

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -258,7 +258,7 @@ export async function getClaimableRewardRPSData(
   return { position, epochNum, balanceChangeIndex };
 }
 
-export async function getPendingRewardRPSData(
+export async function getTotalRewardRPSData(
   hydraChain: HydraChain,
   hydraDelegation: HydraDelegation,
   validator: string,


### PR DESCRIPTION
- initialize the sumReward when assigning a reward to it in the claimPositionReward function;
- rename sumReward -> reward;
- separate the rewards calculations into two functions - calculatePositionClaimableReward  and calculatePositionPendingReward;
- optimize comments and natspec;
- optimize rewardParams and claimPositionReward functions;
- optimize helper functions for the tests;
- add tests and optimize the test's helper re-usability;

EDIT: We added functions in both vested delegation and vested staking modules that can return the claimable rewards and the total (pending/non-matured + claimable) rewards for a vested position.