### PR TITLE
252 change ban working mechanism

### DIFF
--- a/contracts/HydraChain/HydraChain.sol
+++ b/contracts/HydraChain/HydraChain.sol
@@ -152,24 +152,16 @@ contract HydraChain is
     // _______________ Public functions _______________
 
     /**
-     * @notice Returns if a given validator is subject to a ban
      * @dev Apply custom rules for ban eligibility
-     * @param validator The address of the validator
-     * @return Returns true if the validator is subject to a ban
      */
-    function isSubjectToBan(address validator) public view override returns (bool) {
-        // check if the owner (governance) is calling or the validator is already subject to ban on previous exit
-        if (msg.sender == owner()) {
-            return true;
-        }
-
+    function isSubjectToInitiateBan(address validator) public view override returns (bool) {
         uint256 lastCommittedEndBlock = _commitBlockNumbers[currentEpochId - 1];
         uint256 validatorParticipation = validatorsParticipation[validator];
         // check if the validator is active and the last participation is less than the threshold
         if (
             validators[validator].status == ValidatorStatus.Active &&
             lastCommittedEndBlock > validatorParticipation &&
-            lastCommittedEndBlock - validatorParticipation >= banThreshold
+            lastCommittedEndBlock - validatorParticipation >= initiateBanThreshold
         ) {
             return true;
         }

--- a/contracts/HydraChain/HydraChain.sol
+++ b/contracts/HydraChain/HydraChain.sol
@@ -139,14 +139,13 @@ contract HydraChain is
             uint256 commission,
             uint256 withdrawableRewards,
             uint256 votingPower,
-            ValidatorStatus status
+            ValidatorStatus status,
+            bool isbanInitiated
         )
     {
         (blsKey, stake, totalStake, commission, withdrawableRewards, status) = _getValidator(validatorAddress);
-
         votingPower = validatorPower[validatorAddress];
-
-        return (blsKey, stake, totalStake, commission, withdrawableRewards, votingPower, status);
+        isbanInitiated = bansInitiated[validatorAddress] != 0;
     }
 
     // _______________ Public functions _______________

--- a/contracts/HydraChain/IHydraChain.sol
+++ b/contracts/HydraChain/IHydraChain.sol
@@ -70,6 +70,7 @@ interface IHydraChain is IInspector, IValidatorManager, IDaoIncentive, IValidato
             uint256 commission,
             uint256 withdrawableRewards,
             uint256 votingPower,
-            ValidatorStatus status
+            ValidatorStatus status,
+            bool isbanInitiated
         );
 }

--- a/contracts/HydraChain/modules/Inspector/IInspector.sol
+++ b/contracts/HydraChain/modules/Inspector/IInspector.sol
@@ -5,6 +5,9 @@ interface IInspector {
     event ValidatorBanned(address indexed validator);
 
     error NoBanSubject();
+    error NoInitiateBanSubject();
+    error BanAlreadyInitiated();
+    error NoBanInititatedPhase();
 
     /**
      * @notice Set the penalty amount for the banned validators
@@ -23,6 +26,17 @@ interface IInspector {
      * @param newThreshold The new threshold in blocks
      */
     function setBanThreshold(uint256 newThreshold) external;
+
+    /**
+     * @notice Method used to initiate a ban for validator, if the initiate ban threshold is reached
+     * @param validator Address of the validator
+     */
+    function initiateBan(address validator) external;
+
+    /**
+     * @notice Method used to terminate the ban procedure
+     */
+    function terminateBanProcedure() external;
 
     /**
      * @notice Method used to ban a validator, if the ban threshold is reached

--- a/contracts/HydraChain/modules/Inspector/IInspector.sol
+++ b/contracts/HydraChain/modules/Inspector/IInspector.sol
@@ -7,7 +7,7 @@ interface IInspector {
     error NoBanSubject();
     error NoInitiateBanSubject();
     error BanAlreadyInitiated();
-    error NoBanInititatedPhase();
+    error NoBanInititated();
 
     /**
      * @notice Set the penalty amount for the banned validators
@@ -22,7 +22,13 @@ interface IInspector {
     function setReporterReward(uint256 newReward) external;
 
     /**
-     * @notice Set the threshold that needs to be reached to ban a validator
+     * @notice Set the threshold that needs to be reached to initiate the ban procedure (in blocks)
+     * @param newThreshold The new threshold in blocks
+     */
+    function setInitiateBanThreshold(uint256 newThreshold) external;
+
+    /**
+     * @notice Set the threshold that needs to be reached to finish the ban procedure (in milliseconds)
      * @param newThreshold The new threshold in blocks
      */
     function setBanThreshold(uint256 newThreshold) external;

--- a/contracts/HydraChain/modules/Inspector/Inspector.sol
+++ b/contracts/HydraChain/modules/Inspector/Inspector.sol
@@ -56,7 +56,7 @@ abstract contract Inspector is IInspector, ValidatorManager {
         }
 
         bansInitiated[validator] = block.timestamp;
-        hydraStakingContract.temporaryRemove(validator);
+        hydraStakingContract.temporaryEjectValidator(validator);
     }
 
     /**
@@ -68,7 +68,7 @@ abstract contract Inspector is IInspector, ValidatorManager {
         }
 
         bansInitiated[msg.sender] = 0;
-        hydraStakingContract.returnBack(msg.sender);
+        hydraStakingContract.recoverEjectedValidator(msg.sender);
     }
 
     /**
@@ -126,7 +126,8 @@ abstract contract Inspector is IInspector, ValidatorManager {
             return true;
         }
 
-        if (bansInitiated[account] == 0 || block.timestamp - bansInitiated[account] < banThreshold) {
+        uint256 banInitiatedTimestamp = bansInitiated[account];
+        if (banInitiatedTimestamp == 0 || block.timestamp - banInitiatedTimestamp < banThreshold) {
             return false;
         }
 

--- a/contracts/HydraChain/modules/Inspector/Inspector.sol
+++ b/contracts/HydraChain/modules/Inspector/Inspector.sol
@@ -64,7 +64,7 @@ abstract contract Inspector is IInspector, ValidatorManager {
      */
     function terminateBanProcedure() external {
         if (bansInitiated[msg.sender] == 0) {
-            revert NoBanInititatedPhase();
+            revert NoBanInititated();
         }
 
         bansInitiated[msg.sender] = 0;
@@ -79,8 +79,8 @@ abstract contract Inspector is IInspector, ValidatorManager {
             revert NoBanSubject();
         }
 
-        if (bansInitiated[msg.sender] != 0) {
-            bansInitiated[msg.sender] = 0;
+        if (bansInitiated[validator] != 0) {
+            bansInitiated[validator] = 0;
         }
 
         _ban(validator);
@@ -98,6 +98,13 @@ abstract contract Inspector is IInspector, ValidatorManager {
      */
     function setReporterReward(uint256 newReward) external onlyOwner {
         reporterReward = newReward;
+    }
+
+    /**
+     * @inheritdoc IInspector
+     */
+    function setInitiateBanThreshold(uint256 newThreshold) external onlyOwner {
+        initiateBanThreshold = newThreshold;
     }
 
     /**

--- a/contracts/HydraStaking/HydraStaking.sol
+++ b/contracts/HydraStaking/HydraStaking.sol
@@ -98,14 +98,14 @@ contract HydraStaking is
     /**
      * @inheritdoc IHydraStaking
      */
-    function temporaryRemove(address account) external onlyHydraChain {
+    function temporaryEjectValidator(address account) external onlyHydraChain {
         emit BalanceChanged(account, 0);
     }
 
     /**
      * @inheritdoc IHydraStaking
      */
-    function returnBack(address account) external onlyHydraChain {
+    function recoverEjectedValidator(address account) external onlyHydraChain {
         _syncState(account);
     }
 

--- a/contracts/HydraStaking/HydraStaking.sol
+++ b/contracts/HydraStaking/HydraStaking.sol
@@ -95,6 +95,20 @@ contract HydraStaking is
         distributedRewardPerEpoch[epochId] = totalReward;
     }
 
+    /**
+     * @inheritdoc IHydraStaking
+     */
+    function temporaryRemove(address account) external onlyHydraChain {
+        emit BalanceChanged(account, 0);
+    }
+
+    /**
+     * @inheritdoc IHydraStaking
+     */
+    function returnBack(address account) external onlyHydraChain {
+        _syncState(account);
+    }
+
     // _______________ Public functions _______________
 
     /**

--- a/contracts/HydraStaking/IHydraStaking.sol
+++ b/contracts/HydraStaking/IHydraStaking.sol
@@ -23,6 +23,21 @@ interface IHydraStaking is IDelegatedStaking, IStaking, ILiquidStaking, IPenaliz
      */
     function distributeRewardsFor(uint256 epochId, Uptime[] calldata uptime) external;
 
+    /**
+     * Allows temporary removal of a validator from the validator set by emiting a balance changed event
+     * @dev It breaks the normal flow of the system contracts
+     * but is the fastest way to achieve two-step ban functionality
+     * @param account address of the validator to be removed
+     */
+    function temporaryRemove(address account) external;
+
+    /**
+     * Return back a validator after temporary removal from the validator set by emiting a balance changed event
+     * @dev related to the temporaryRemove function
+     * @param account address of the validator to be returned
+     */
+    function returnBack(address account) external;
+
     // _______________ Public functions _______________
 
     /**

--- a/contracts/HydraStaking/IHydraStaking.sol
+++ b/contracts/HydraStaking/IHydraStaking.sol
@@ -29,14 +29,14 @@ interface IHydraStaking is IDelegatedStaking, IStaking, ILiquidStaking, IPenaliz
      * but is the fastest way to achieve two-step ban functionality
      * @param account address of the validator to be removed
      */
-    function temporaryRemove(address account) external;
+    function temporaryEjectValidator(address account) external;
 
     /**
      * Return back a validator after temporary removal from the validator set by emiting a balance changed event
-     * @dev related to the temporaryRemove function
+     * @dev related to the temporaryEjectValidator function
      * @param account address of the validator to be returned
      */
-    function returnBack(address account) external;
+    function recoverEjectedValidator(address account) external;
 
     // _______________ Public functions _______________
 

--- a/docs/HydraChain/HydraChain.md
+++ b/docs/HydraChain/HydraChain.md
@@ -229,7 +229,7 @@ function aprCalculatorContract() external view returns (contract IAPRCalculator)
 function banThreshold() external view returns (uint256)
 ```
 
-Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator
+Validator inactiveness (in milliseconds) threshold that needs to be passed to ban a validator
 
 
 
@@ -255,6 +255,28 @@ Method used to ban a validator, if the ban threshold is reached
 | Name | Type | Description |
 |---|---|---|
 | validator | address | Address of the validator |
+
+### bansInitiated
+
+```solidity
+function bansInitiated(address) external view returns (uint256)
+```
+
+Mapping of the validators that bans has been initiated for (validator =&gt; timestamp)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### bls
 
@@ -508,7 +530,7 @@ Returns the total voting power of the validators
 ### getValidator
 
 ```solidity
-function getValidator(address validatorAddress) external view returns (uint256[4] blsKey, uint256 stake, uint256 totalStake, uint256 commission, uint256 withdrawableRewards, uint256 votingPower, enum ValidatorStatus status)
+function getValidator(address validatorAddress) external view returns (uint256[4] blsKey, uint256 stake, uint256 totalStake, uint256 commission, uint256 withdrawableRewards, uint256 votingPower, enum ValidatorStatus status, bool isbanInitiated)
 ```
 
 Gets validator by address.
@@ -532,6 +554,7 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | votingPower | uint256 | voting power of the validator |
 | status | enum ValidatorStatus | status of the validator |
+| isbanInitiated | bool | undefined |
 
 ### getValidatorPower
 
@@ -629,13 +652,68 @@ function initialize(ValidatorInit[] newValidators, address governance, address h
 | daoIncentiveVaultAddr | address | undefined |
 | newBls | contract IBLS | undefined |
 
-### isSubjectToBan
+### initiateBan
 
 ```solidity
-function isSubjectToBan(address validator) external view returns (bool)
+function initiateBan(address validator) external nonpayable
 ```
 
-Returns if a given validator is subject to a ban
+Method used to initiate a ban for validator, if the initiate ban threshold is reached
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+### initiateBanThreshold
+
+```solidity
+function initiateBanThreshold() external view returns (uint256)
+```
+
+Validator inactiveness (in blocks) threshold that needs to be passed to initiate ban for a validator
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### isSubjectToFinishBan
+
+```solidity
+function isSubjectToFinishBan(address account) external view returns (bool)
+```
+
+Returns true if a ban can be finally executed for a given validator
+
+*override this function to apply your custom rules*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### isSubjectToInitiateBan
+
+```solidity
+function isSubjectToInitiateBan(address validator) external view returns (bool)
+```
+
+
 
 *Apply custom rules for ban eligibility*
 
@@ -643,13 +721,13 @@ Returns if a given validator is subject to a ban
 
 | Name | Type | Description |
 |---|---|---|
-| validator | address | The address of the validator |
+| validator | address | undefined |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Returns true if the validator is subject to a ban |
+| _0 | bool | undefined |
 
 ### isValidatorActive
 
@@ -908,7 +986,23 @@ function rewardWalletContract() external view returns (contract IRewardWallet)
 function setBanThreshold(uint256 newThreshold) external nonpayable
 ```
 
-Set the threshold that needs to be reached to ban a validator
+Set the threshold that needs to be reached to finish the ban procedure (in milliseconds)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
+### setInitiateBanThreshold
+
+```solidity
+function setInitiateBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to initiate the ban procedure (in blocks)
 
 
 
@@ -965,6 +1059,17 @@ function syncValidatorsData(ValidatorPower[] validatorsPower) external nonpayabl
 | Name | Type | Description |
 |---|---|---|
 | validatorsPower | ValidatorPower[] | undefined |
+
+### terminateBanProcedure
+
+```solidity
+function terminateBanProcedure() external nonpayable
+```
+
+Method used to terminate the ban procedure
+
+
+
 
 ### totalBlocks
 
@@ -1350,6 +1455,17 @@ event VaultFundsDistributed(uint256 amount)
 
 ## Errors
 
+### BanAlreadyInitiated
+
+```solidity
+error BanAlreadyInitiated()
+```
+
+
+
+
+
+
 ### CommitEpochFailed
 
 ```solidity
@@ -1431,10 +1547,32 @@ error MustBeWhitelisted()
 
 
 
+### NoBanInititated
+
+```solidity
+error NoBanInititated()
+```
+
+
+
+
+
+
 ### NoBanSubject
 
 ```solidity
 error NoBanSubject()
+```
+
+
+
+
+
+
+### NoInitiateBanSubject
+
+```solidity
+error NoInitiateBanSubject()
 ```
 
 

--- a/docs/HydraChain/IHydraChain.md
+++ b/docs/HydraChain/IHydraChain.md
@@ -175,7 +175,7 @@ Returns the total voting power of the validators
 ### getValidator
 
 ```solidity
-function getValidator(address validator) external view returns (uint256[4] blsKey, uint256 stake, uint256 totalStake, uint256 commission, uint256 withdrawableRewards, uint256 votingPower, enum ValidatorStatus status)
+function getValidator(address validator) external view returns (uint256[4] blsKey, uint256 stake, uint256 totalStake, uint256 commission, uint256 withdrawableRewards, uint256 votingPower, enum ValidatorStatus status, bool isbanInitiated)
 ```
 
 Gets validator by address.
@@ -199,6 +199,7 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | votingPower | uint256 | voting power of the validator |
 | status | enum ValidatorStatus | status of the validator |
+| isbanInitiated | bool | undefined |
 
 ### getValidatorPower
 
@@ -238,6 +239,22 @@ Gets all validators. Returns already unactive validators as well.
 | Name | Type | Description |
 |---|---|---|
 | _0 | address[] | Returns array of addresses |
+
+### initiateBan
+
+```solidity
+function initiateBan(address validator) external nonpayable
+```
+
+Method used to initiate a ban for validator, if the initiate ban threshold is reached
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
 
 ### isValidatorActive
 
@@ -328,7 +345,23 @@ Validates BLS signature with the provided pubkey and registers validators into t
 function setBanThreshold(uint256 newThreshold) external nonpayable
 ```
 
-Set the threshold that needs to be reached to ban a validator
+Set the threshold that needs to be reached to finish the ban procedure (in milliseconds)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
+### setInitiateBanThreshold
+
+```solidity
+function setInitiateBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to initiate the ban procedure (in blocks)
 
 
 
@@ -385,6 +418,17 @@ function syncValidatorsData(ValidatorPower[] validatorsPower) external nonpayabl
 | Name | Type | Description |
 |---|---|---|
 | validatorsPower | ValidatorPower[] | undefined |
+
+### terminateBanProcedure
+
+```solidity
+function terminateBanProcedure() external nonpayable
+```
+
+Method used to terminate the ban procedure
+
+
+
 
 ### totalBlocks
 
@@ -532,6 +576,17 @@ event VaultFundsDistributed(uint256 amount)
 
 ## Errors
 
+### BanAlreadyInitiated
+
+```solidity
+error BanAlreadyInitiated()
+```
+
+
+
+
+
+
 ### CommitEpochFailed
 
 ```solidity
@@ -602,10 +657,32 @@ error MaxValidatorsReached()
 
 
 
+### NoBanInititated
+
+```solidity
+error NoBanInititated()
+```
+
+
+
+
+
+
 ### NoBanSubject
 
 ```solidity
 error NoBanSubject()
+```
+
+
+
+
+
+
+### NoInitiateBanSubject
+
+```solidity
+error NoInitiateBanSubject()
 ```
 
 

--- a/docs/HydraChain/modules/Inspector/IInspector.md
+++ b/docs/HydraChain/modules/Inspector/IInspector.md
@@ -26,13 +26,45 @@ Method used to ban a validator, if the ban threshold is reached
 |---|---|---|
 | validator | address | Address of the validator |
 
+### initiateBan
+
+```solidity
+function initiateBan(address validator) external nonpayable
+```
+
+Method used to initiate a ban for validator, if the initiate ban threshold is reached
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
 ### setBanThreshold
 
 ```solidity
 function setBanThreshold(uint256 newThreshold) external nonpayable
 ```
 
-Set the threshold that needs to be reached to ban a validator
+Set the threshold that needs to be reached to finish the ban procedure (in milliseconds)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
+### setInitiateBanThreshold
+
+```solidity
+function setInitiateBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to initiate the ban procedure (in blocks)
 
 
 
@@ -74,6 +106,17 @@ Set the penalty amount for the banned validators
 |---|---|---|
 | newPenalty | uint256 | Amount of the penalty |
 
+### terminateBanProcedure
+
+```solidity
+function terminateBanProcedure() external nonpayable
+```
+
+Method used to terminate the ban procedure
+
+
+
+
 
 
 ## Events
@@ -98,10 +141,43 @@ event ValidatorBanned(address indexed validator)
 
 ## Errors
 
+### BanAlreadyInitiated
+
+```solidity
+error BanAlreadyInitiated()
+```
+
+
+
+
+
+
+### NoBanInititated
+
+```solidity
+error NoBanInititated()
+```
+
+
+
+
+
+
 ### NoBanSubject
 
 ```solidity
 error NoBanSubject()
+```
+
+
+
+
+
+
+### NoInitiateBanSubject
+
+```solidity
+error NoInitiateBanSubject()
 ```
 
 

--- a/docs/HydraChain/modules/Inspector/Inspector.md
+++ b/docs/HydraChain/modules/Inspector/Inspector.md
@@ -212,7 +212,7 @@ Adds addresses that are allowed to register as validators.
 function banThreshold() external view returns (uint256)
 ```
 
-Validator inactiveness (in blocks) threshold that needs to be passed to ban a validator
+Validator inactiveness (in milliseconds) threshold that needs to be passed to ban a validator
 
 
 
@@ -238,6 +238,28 @@ Method used to ban a validator, if the ban threshold is reached
 | Name | Type | Description |
 |---|---|---|
 | validator | address | Address of the validator |
+
+### bansInitiated
+
+```solidity
+function bansInitiated(address) external view returns (uint256)
+```
+
+Mapping of the validators that bans has been initiated for (validator =&gt; timestamp)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
 
 ### bls
 
@@ -362,13 +384,46 @@ function hydraStakingContract() external view returns (contract IHydraStaking)
 |---|---|---|
 | _0 | contract IHydraStaking | undefined |
 
-### isSubjectToBan
+### initiateBan
 
 ```solidity
-function isSubjectToBan(address account) external nonpayable returns (bool)
+function initiateBan(address validator) external nonpayable
 ```
 
-Returns if a given validator is subject to a ban
+Method used to initiate a ban for validator, if the initiate ban threshold is reached
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+### initiateBanThreshold
+
+```solidity
+function initiateBanThreshold() external view returns (uint256)
+```
+
+Validator inactiveness (in blocks) threshold that needs to be passed to initiate ban for a validator
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### isSubjectToFinishBan
+
+```solidity
+function isSubjectToFinishBan(address account) external view returns (bool)
+```
+
+Returns true if a ban can be finally executed for a given validator
 
 *override this function to apply your custom rules*
 
@@ -383,6 +438,28 @@ Returns if a given validator is subject to a ban
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
+
+### isSubjectToInitiateBan
+
+```solidity
+function isSubjectToInitiateBan(address account) external nonpayable returns (bool)
+```
+
+Returns if a ban process can be initiated for a given validator
+
+*override this function to apply your custom rules*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | The address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | Returns true if the validator is subject to a ban |
 
 ### isValidatorActive
 
@@ -607,7 +684,23 @@ The reward for the person who reports a validator that have to be banned
 function setBanThreshold(uint256 newThreshold) external nonpayable
 ```
 
-Set the threshold that needs to be reached to ban a validator
+Set the threshold that needs to be reached to finish the ban procedure (in milliseconds)
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newThreshold | uint256 | The new threshold in blocks |
+
+### setInitiateBanThreshold
+
+```solidity
+function setInitiateBanThreshold(uint256 newThreshold) external nonpayable
+```
+
+Set the threshold that needs to be reached to initiate the ban procedure (in blocks)
 
 
 
@@ -648,6 +741,17 @@ Set the penalty amount for the banned validators
 | Name | Type | Description |
 |---|---|---|
 | newPenalty | uint256 | Amount of the penalty |
+
+### terminateBanProcedure
+
+```solidity
+function terminateBanProcedure() external nonpayable
+```
+
+Method used to terminate the ban procedure
+
+
+
 
 ### transferOwnership
 
@@ -904,6 +1008,17 @@ event ValidatorBanned(address indexed validator)
 
 ## Errors
 
+### BanAlreadyInitiated
+
+```solidity
+error BanAlreadyInitiated()
+```
+
+
+
+
+
+
 ### InvalidCommission
 
 ```solidity
@@ -969,10 +1084,32 @@ error MustBeWhitelisted()
 
 
 
+### NoBanInititated
+
+```solidity
+error NoBanInititated()
+```
+
+
+
+
+
+
 ### NoBanSubject
 
 ```solidity
 error NoBanSubject()
+```
+
+
+
+
+
+
+### NoInitiateBanSubject
+
+```solidity
+error NoInitiateBanSubject()
 ```
 
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -733,6 +733,22 @@ function renounceRole(bytes32 role, address account) external nonpayable
 | role | bytes32 | undefined |
 | account | address | undefined |
 
+### returnBack
+
+```solidity
+function returnBack(address account) external nonpayable
+```
+
+Return back a validator after temporary removal from the validator set by emiting a balance changed event
+
+*related to the temporaryRemove function*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the validator to be returned |
+
 ### revokeRole
 
 ```solidity
@@ -907,6 +923,22 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
+
+### temporaryRemove
+
+```solidity
+function temporaryRemove(address account) external nonpayable
+```
+
+Allows temporary removal of a validator from the validator set by emiting a balance changed event
+
+*It breaks the normal flow of the system contracts but is the fastest way to achieve two-step ban functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the validator to be removed |
 
 ### totalBalance
 

--- a/docs/HydraStaking/HydraStaking.md
+++ b/docs/HydraStaking/HydraStaking.md
@@ -705,6 +705,22 @@ Calculates how much is yet to become withdrawable for account.
 |---|---|---|
 | _0 | uint256 | Amount not yet withdrawable (in wei) |
 
+### recoverEjectedValidator
+
+```solidity
+function recoverEjectedValidator(address account) external nonpayable
+```
+
+Return back a validator after temporary removal from the validator set by emiting a balance changed event
+
+*related to the temporaryEjectValidator function*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the validator to be returned |
+
 ### renounceOwnership
 
 ```solidity
@@ -732,22 +748,6 @@ function renounceRole(bytes32 role, address account) external nonpayable
 |---|---|---|
 | role | bytes32 | undefined |
 | account | address | undefined |
-
-### returnBack
-
-```solidity
-function returnBack(address account) external nonpayable
-```
-
-Return back a validator after temporary removal from the validator set by emiting a balance changed event
-
-*related to the temporaryRemove function*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| account | address | address of the validator to be returned |
 
 ### revokeRole
 
@@ -924,10 +924,10 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 |---|---|---|
 | _0 | bool | undefined |
 
-### temporaryRemove
+### temporaryEjectValidator
 
 ```solidity
-function temporaryRemove(address account) external nonpayable
+function temporaryEjectValidator(address account) external nonpayable
 ```
 
 Allows temporary removal of a validator from the validator set by emiting a balance changed event

--- a/docs/HydraStaking/IHydraStaking.md
+++ b/docs/HydraStaking/IHydraStaking.md
@@ -181,6 +181,22 @@ Calculates how much is yet to become withdrawable for account.
 |---|---|---|
 | _0 | uint256 | Amount not yet withdrawable (in wei) |
 
+### returnBack
+
+```solidity
+function returnBack(address account) external nonpayable
+```
+
+Return back a validator after temporary removal from the validator set by emiting a balance changed event
+
+*related to the temporaryRemove function*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the validator to be returned |
+
 ### stake
 
 ```solidity
@@ -213,6 +229,22 @@ Returns staked amount for the given account.
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | undefined |
+
+### temporaryRemove
+
+```solidity
+function temporaryRemove(address account) external nonpayable
+```
+
+Allows temporary removal of a validator from the validator set by emiting a balance changed event
+
+*It breaks the normal flow of the system contracts but is the fastest way to achieve two-step ban functionality*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | address of the validator to be removed |
 
 ### totalBalance
 

--- a/docs/HydraStaking/IHydraStaking.md
+++ b/docs/HydraStaking/IHydraStaking.md
@@ -181,15 +181,15 @@ Calculates how much is yet to become withdrawable for account.
 |---|---|---|
 | _0 | uint256 | Amount not yet withdrawable (in wei) |
 
-### returnBack
+### recoverEjectedValidator
 
 ```solidity
-function returnBack(address account) external nonpayable
+function recoverEjectedValidator(address account) external nonpayable
 ```
 
 Return back a validator after temporary removal from the validator set by emiting a balance changed event
 
-*related to the temporaryRemove function*
+*related to the temporaryEjectValidator function*
 
 #### Parameters
 
@@ -230,10 +230,10 @@ Returns staked amount for the given account.
 |---|---|---|
 | _0 | uint256 | undefined |
 
-### temporaryRemove
+### temporaryEjectValidator
 
 ```solidity
-function temporaryRemove(address account) external nonpayable
+function temporaryEjectValidator(address account) external nonpayable
 ```
 
 Allows temporary removal of a validator from the validator set by emiting a balance changed event

--- a/test/HydraChain/HydraChain.test.ts
+++ b/test/HydraChain/HydraChain.test.ts
@@ -147,7 +147,8 @@ export function RunHydraChainTests(): void {
         // Inspector
         expect(await hydraChain.validatorPenalty()).to.equal(hre.ethers.utils.parseEther("700"));
         expect(await hydraChain.reporterReward()).to.equal(hre.ethers.utils.parseEther("300"));
-        expect(await hydraChain.banThreshold()).to.equal(123428);
+        expect(await hydraChain.initiateBanThreshold()).to.equal(18000);
+        expect(await hydraChain.banThreshold()).to.equal(60 * 60 * 24);
       });
 
       it("should revert on re-initialization attempt", async function () {

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -27,6 +27,7 @@ export const INITIAL_PRICE = 500;
 export const FAST_SMA = 115;
 export const SLOW_SMA = 310;
 export const ARRAY_310_ELEMENTS: number[] = Array(310).fill(INITIAL_PRICE);
+export const BAN_THRESHOLD = 60 * 60 * 24; // 24 hours
 /* eslint-disable no-unused-vars */
 export enum VALIDATOR_STATUS {
   None = 0,

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -556,7 +556,7 @@ async function validatorToBanFixtureFunction(this: Mocha.Context) {
   // lower the threshold in order to easily reach it
   const banThreshold = hre.ethers.BigNumber.from(100);
   const hydraChainGov = hydraChain.connect(this.signers.governance);
-  await hydraChainGov.setBanThreshold(banThreshold);
+  await hydraChainGov.setInitiateBanThreshold(banThreshold);
 
   // commit epochs, but without the validator that will be banned
   await commitEpochs(
@@ -577,6 +577,18 @@ async function validatorToBanFixtureFunction(this: Mocha.Context) {
     hydraChain,
     hydraStaking,
     validatorToBan: validator,
+  };
+}
+
+async function banInitiatedFixtureFunction(this: Mocha.Context) {
+  const { hydraChain, hydraStaking, validatorToBan } = await loadFixture(this.fixtures.validatorToBanFixture);
+
+  await hydraChain.connect(this.signers.governance).initiateBan(validatorToBan.address);
+
+  return {
+    hydraChain,
+    hydraStaking,
+    inBanProcessValidator: validatorToBan,
   };
 }
 
@@ -992,6 +1004,7 @@ export async function generateFixtures(context: Mocha.Context) {
   context.fixtures.vestedDelegationFixture = vestedDelegationFixtureFunction.bind(context);
   context.fixtures.weeklyVestedDelegationFixture = weeklyVestedDelegationFixtureFunction.bind(context);
   context.fixtures.validatorToBanFixture = validatorToBanFixtureFunction.bind(context);
+  context.fixtures.banInitiatedFixtureFunction = banInitiatedFixtureFunction.bind(context);
   context.fixtures.bannedValidatorFixture = bannedValidatorFixtureFunction.bind(context);
   context.fixtures.swappedPositionFixture = swappedPositionFixtureFunction.bind(context);
 }

--- a/test/mochaContext.ts
+++ b/test/mochaContext.ts
@@ -280,6 +280,13 @@ export interface Fixtures {
       validatorToBan: SignerWithAddress;
     }>;
   };
+  banInitiatedFixtureFunction: {
+    (): Promise<{
+      hydraChain: HydraChain;
+      hydraStaking: HydraStaking;
+      inBanProcessValidator: SignerWithAddress;
+    }>;
+  };
   bannedValidatorFixture: {
     (): Promise<{
       hydraChain: HydraChain;


### PR DESCRIPTION
Implement a two-step ban process that involves initiating and ending the ban in case the validator doesn't terminate it. That way, we eject offline validators faster and give them some time to return.